### PR TITLE
feat: add dotnet tool packaging to release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
           versionSpec: '6.6.x'
       - uses: gittools/actions/gitversion/execute@v4.2.0
         id: gitversion
-      - run: dotnet build -c Release /p:Version=${{ steps.gitversion.outputs.semVer }}
+      - run: dotnet build -c Release -p:Version=${{ steps.gitversion.outputs.semVer }}
       - run: dotnet test -c Release --no-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
           versionSpec: '6.6.x'
       - uses: gittools/actions/gitversion/execute@v4.2.0
         id: gitversion
-      - run: dotnet build -c Release /p:Version=${{ steps.gitversion.outputs.semVer }}
+      - run: dotnet build -c Release -p:Version=${{ steps.gitversion.outputs.semVer }}
+      - run: dotnet pack src/MemoryLens.Mcp/MemoryLens.Mcp.csproj -c Release --no-build -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} -o ./nupkg
       - name: Generate changelog
         id: changelog
         uses: requarks/changelog-action@v1

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,5 @@
 workflow: GitHubFlow/v1
+next-version: 0.1.0
 strategies:
   - ConfiguredNextVersion
   - Mainline

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,7 +2,6 @@ workflow: GitHubFlow/v1
 next-version: 0.1.0
 strategies:
   - ConfiguredNextVersion
-  - Mainline
 major-version-bump-message: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([\w\s-,/\\]*\))?(!:|:.*\n\n((.+\n)+\n)?BREAKING CHANGE:\s.+)'
 minor-version-bump-message: '^(feat)(\([\w\s-,/\\]*\))?:'
 patch-version-bump-message: '^(fix|perf)(\([\w\s-,/\\]*\))?:'

--- a/src/MemoryLens.Mcp/MemoryLens.Mcp.csproj
+++ b/src/MemoryLens.Mcp/MemoryLens.Mcp.csproj
@@ -6,7 +6,23 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+
+    <!-- NuGet dotnet tool packaging -->
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>memorylens-mcp</ToolCommandName>
+    <PackageId>MemoryLens.Mcp</PackageId>
+    <Authors>Marcel Roozekrans</Authors>
+    <Description>MCP server for .NET memory profiling — wraps JetBrains dotnet-dotmemory with heuristic-based analysis rules</Description>
+    <PackageProjectUrl>https://github.com/MarcelRoozekrans/memorylens-mcp</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/MarcelRoozekrans/memorylens-mcp</RepositoryUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>mcp;memory;profiling;dotmemory;diagnostics;dotnet-tool</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />


### PR DESCRIPTION
## Summary
- Configure project as a dotnet tool (`PackAsTool`) with NuGet metadata
- Add `dotnet pack` step to release workflow so `.nupkg` is built on tagged releases
- Fix `/p:` to `-p:` syntax for cross-platform compatibility

## Test plan
- [x] `dotnet pack` produces valid `.nupkg`
- [x] Build and tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)