### PR TITLE
feat: add NuGet publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
         id: gitversion
       - run: dotnet build -c Release -p:Version=${{ steps.gitversion.outputs.semVer }}
       - run: dotnet pack src/MemoryLens.Mcp/MemoryLens.Mcp.csproj -c Release --no-build -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} -o ./nupkg
+      - name: Push to NuGet
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
       - name: Generate changelog
         id: changelog
         uses: requarks/changelog-action@v1
@@ -34,4 +36,5 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body: ${{ steps.changelog.outputs.changes }}
+          files: ./nupkg/*.nupkg
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `dotnet nuget push` step to publish `.nupkg` to nuget.org on tagged releases
- Attach `.nupkg` as GitHub Release download asset
- Changelog already auto-generated from conventional commits via `requarks/changelog-action`

## Prerequisites
- Add `NUGET_API_KEY` secret in GitHub repo settings (Settings > Secrets > Actions)

## Release flow
1. Push a tag: `git tag v0.1.0 && git push origin v0.1.0`
2. Workflow builds, packs, publishes to NuGet, creates GitHub Release with changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)