### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@
   On-demand .NET memory profiling with concrete, AI-actionable code fix suggestions — wraps JetBrains dotMemory with a heuristic-based rule engine.
 </p>
 
+<a href="https://glama.ai/mcp/servers/MarcelRoozekrans/memorylens-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/MarcelRoozekrans/memorylens-mcp/badge" alt="memorylens-mcp MCP server" />
+</a>
+
 <!-- mcp-name: io.github.marcelroozekrans/memorylens-mcp -->
 
 ---


### PR DESCRIPTION
This PR adds a badge for the [memorylens-mcp](https://glama.ai/mcp/servers/MarcelRoozekrans/memorylens-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/MarcelRoozekrans/memorylens-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/MarcelRoozekrans/memorylens-mcp/badge" alt="memorylens-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.