### PR TITLE
ci: auto-publish to MCP registry after npm release

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,28 @@
+name: Publish to MCP Registry
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-mcp:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz"
+          tar xzf mcp-publisher.tar.gz
+          chmod +x mcp-publisher
+
+      - name: Authenticate via OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release-please:
@@ -51,3 +52,24 @@ jobs:
         run: gh release upload ${{ needs.release-please.outputs.tag_name }} ./nupkg/*.nupkg
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-mcp-registry:
+    name: Publish to MCP Registry
+    needs: [release-please, publish]
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz"
+          tar xzf mcp-publisher.tar.gz
+          chmod +x mcp-publisher
+
+      - name: Authenticate via OIDC
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish

--- a/server.json
+++ b/server.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.marcelroozekrans/memorylens-mcp",
+  "description": "MCP server for .NET memory profiling — wraps JetBrains dotnet-dotmemory with heuristic-based analysis rules",
+  "repository": {
+    "url": "https://github.com/MarcelRoozekrans/memorylens-mcp",
+    "source": "github"
+  },
+  "version": "1.3.1",
+  "packages": [
+    {
+      "registryType": "nuget",
+      "registryBaseUrl": "https://api.nuget.org/v3/index.json",
+      "identifier": "MemoryLens.Mcp",
+      "version": "1.3.1",
+      "runtimeHint": "dnx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Added `publish-mcp-registry` job to `release-please.yml` that runs after the `publish` job succeeds, automatically publishing to the MCP registry on every release
- Added `id-token: write` permission to `release-please.yml` for OIDC authentication with the MCP registry
- Created standalone `publish-mcp-registry.yml` workflow with `workflow_dispatch` trigger for manual ad-hoc re-publishing
- Created root `server.json` with NuGet package metadata for the `mcp-publisher` tool

## Test plan
- [ ] Verify `release-please.yml` YAML is valid (check Actions tab for syntax errors)
- [ ] Trigger `Publish to MCP Registry` workflow manually via `workflow_dispatch` to confirm it runs
- [ ] On next release, confirm the `publish-mcp-registry` job runs after `publish` completes
- [ ] Verify OIDC token is issued correctly (may need to configure the MCP registry side first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)