### PR TITLE
fix: correct MCP registry name casing and shorten description

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.marcelroozekrans/memorylens-mcp",
-  "description": "MCP server for .NET memory profiling — wraps JetBrains dotnet-dotmemory with heuristic-based analysis rules",
+  "name": "io.github.MarcelRoozekrans/memorylens-mcp",
+  "description": "MCP server for .NET memory profiling with JetBrains dotMemory integration",
   "repository": {
     "url": "https://github.com/MarcelRoozekrans/memorylens-mcp",
     "source": "github"


### PR DESCRIPTION
## Summary
- Fix GitHub username casing in `server.json` name field (`MarcelRoozekrans` instead of `marcelroozekrans`) to match registry requirements
- Shorten description to fit within 100-character limit

## Test plan
- [ ] Verify the MCP registry publish workflow succeeds with the corrected name
- [ ] Confirm description length is <= 100 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)