### PR TITLE
fix: add mcp-name to README for MCP registry ownership verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <img width="380" height="200" src="https://glama.ai/mcp/servers/MarcelRoozekrans/memorylens-mcp/badge" alt="memorylens-mcp MCP server" />
 </a>
 
-<!-- mcp-name: io.github.marcelroozekrans/memorylens-mcp -->
+<!-- mcp-name: io.github.MarcelRoozekrans/memorylens-mcp -->
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixes the casing of the `mcp-name` HTML comment in README.md to use `io.github.MarcelRoozekrans/memorylens-mcp` (correct GitHub username casing) for MCP registry ownership verification.

## Test plan
- [ ] Verify the MCP registry can resolve the package ownership after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)