### PR TITLE
fix: include server.json in release-please version bumps

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,19 @@
     ".": {
       "release-type": "simple",
       "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-patch-for-minor-pre-major": true,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "server.json",
+          "jsonpath": "$.packages[0].version"
+        }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/MarcelRoozekrans/memorylens-mcp",
     "source": "github"
   },
-  "version": "1.3.1",
+  "version": "0.0.0",
   "packages": [
     {
       "registryType": "nuget",
       "registryBaseUrl": "https://api.nuget.org/v3/index.json",
       "identifier": "MemoryLens.Mcp",
-      "version": "1.3.1",
+      "version": "0.0.0",
       "runtimeHint": "dnx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- Adds `extra-files` configuration to `release-please-config.json` so that `server.json` version fields (`$.version` and `$.packages[0].version`) are bumped automatically on release.
- Prevents MCP registry publish failures caused by version mismatches between the release and `server.json`.

## Test plan
- [ ] Verify `release-please-config.json` is valid JSON and matches the expected schema
- [ ] Confirm next release-please PR includes `server.json` version bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)