### PR TITLE
feat: auto-download JetBrains dotMemory Console on first use

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,50 +64,51 @@ dotnet tool install -g MemoryLens.Mcp
 
 ## dotMemory CLI Installation
 
-MemoryLens MCP supports multiple ways to install and use JetBrains dotMemory CLI:
+MemoryLens MCP automatically downloads and caches the JetBrains dotMemory CLI on first use via the `ensure_dotmemory` tool — no manual installation required on supported platforms.
 
-### Option 1: Official JetBrains dotMemory CLI (Recommended)
+### Supported Platforms (auto-download)
 
-Use the official dotMemory CLI from JetBrains Toolbox or direct download:
+| Platform | Architecture |
+|---|---|
+| Windows | x64, x86, ARM64 |
+| Linux (glibc) | x64, ARM64, ARM |
+| Linux (musl) | x64, ARM64 |
+| macOS | x64 (Intel), ARM64 (Apple Silicon) |
 
-**JetBrains Toolbox (Linux/macOS):**
+### Cache Location
+
+Downloaded binaries are cached at `~/.memorylens/tools/dotmemory/{version}/`. Old versions are not auto-removed — delete the directory manually to free disk space.
+
+### Unsupported Platforms
+
+Platforms not listed above (e.g. FreeBSD, Linux x86) cannot use auto-download. Set `DOTMEMORY_PATH` to point to an existing dotMemory CLI executable:
+
 ```bash
-# Set DOTMEMORY_PATH to point to your JetBrains Toolbox installation
-export DOTMEMORY_PATH="$HOME/.local/share/JetBrains/Toolbox/apps/rider/tools/profiler/dotMemory.sh"
+export DOTMEMORY_PATH="/path/to/dotMemory.sh"   # Linux/macOS
+set DOTMEMORY_PATH=C:\path\to\dotMemory.exe      # Windows
 ```
 
-**JetBrains Toolbox (Windows):**
-```cmd
-set DOTMEMORY_PATH=%LOCALAPPDATA%\JetBrains\Toolbox\apps\rider\tools\profiler\dotMemory.exe
-```
+Find dotMemory CLI in JetBrains Toolbox:
+- Linux: `~/.local/share/JetBrains/Toolbox/apps/rider/tools/profiler/dotMemory.sh`
+- Windows: `%LOCALAPPDATA%\JetBrains\Toolbox\apps\rider\tools\profiler\dotMemory.exe`
 
-**Direct Installation:**
-Download dotMemory from [jetbrains.com](https://www.jetbrains.com/dotmemory/download/) and set DOTMEMORY_PATH to the CLI executable:
-- Linux/macOS: `<install_dir>/bin/dotMemory.sh`
-- Windows: `<install_dir>\bin\dotMemory.exe`
+### Manual Fallback Discovery
 
-### Option 2: PATH Discovery
+If auto-download is unavailable, MemoryLens MCP falls back through these discovery modes in order:
 
-If dotMemory CLI is in your system PATH, MemoryLens MCP will automatically discover it by searching for:
-- Linux/macOS: `dotMemory.sh`, `dotMemory`
-- Windows: `dotMemory.exe`
+1. **`DOTMEMORY_PATH` environment variable** — explicit path to the CLI executable
+2. **System PATH** — searches for `dotMemory.sh` / `dotMemory` (Linux/macOS) or `dotMemory.exe` (Windows)
+3. **Local .NET tool manifest** — `dotnet tool install dotnet-dotmemory --local`
+4. **Global .NET tool** — `dotnet tool install -g dotnet-dotmemory` (legacy fallback)
 
-### Option 3: Local Tool Manifest
+### Error Scenarios
 
-Use dotMemory as a local .NET tool in your project:
-```bash
-dotnet new tool-manifest
-dotnet tool install dotnet-dotmemory --local
-```
-
-### Option 4: Global Tool (Legacy)
-
-Install as a global .NET tool (legacy fallback):
-```bash
-dotnet tool install -g dotnet-dotmemory
-```
-
-**Note:** The `dotnet-dotmemory` global tool is not distributed by JetBrains and may not be available in all NuGet feeds. Official JetBrains dotMemory CLI (Option 1) is recommended.
+| Error | Cause | Fix |
+|---|---|---|
+| `Platform '...' is not supported` | Unsupported OS/arch | Set `DOTMEMORY_PATH` |
+| Network/download failure | No internet / NuGet unreachable | Set `DOTMEMORY_PATH` or retry `ensure_dotmemory` |
+| `chmod +x failed` | Read-only filesystem | Set `DOTMEMORY_PATH` to a writable location |
+| `dotMemory CLI not found` | All discovery modes failed | Run `ensure_dotmemory` or set `DOTMEMORY_PATH` |
 
 ## Available MCP Tools
 

--- a/docs/plans/2026-04-14-dotmemory-auto-install-design.md
+++ b/docs/plans/2026-04-14-dotmemory-auto-install-design.md
@@ -1,0 +1,129 @@
+# Design: dotMemory Auto-Install via NuGet Download
+
+**Date:** 2026-04-14
+**Status:** Approved
+
+## Problem
+
+`MemoryLens.Mcp` originally assumed `dotnet-dotmemory` existed as a NuGet global tool. It does not — JetBrains does not publish dotMemory CLI that way. PR #42 added `DOTMEMORY_PATH` and PATH discovery as a workaround, but still requires users to manually install dotMemory and configure the path.
+
+## Goal
+
+Make dotMemory work out of the box with zero user setup on all supported platforms, by automatically downloading the official `JetBrains.dotMemory.Console.*` redistributable NuGet packages on first use.
+
+## Approach: Download on First Use
+
+When `ensure_dotmemory` is called and no dotMemory binary is found via existing discovery modes, automatically download and cache the correct platform package from NuGet. On subsequent runs, use the cached binary — no network call needed.
+
+---
+
+## Section 1: Architecture
+
+A new `DotMemoryCommandKind.AutoInstalled` is added. `DotMemoryToolManager.ResolveCommandAsync` gains a new step `ResolveAutoInstalledAsync` inserted after `DOTMEMORY_PATH` but before PATH discovery:
+
+```
+DOTMEMORY_PATH → AutoInstalled (cached) → PATH → LocalTool → GlobalTool
+```
+
+The download logic lives in a new `DotMemoryAutoInstaller` class, injected into `DotMemoryToolManager` via `IDotMemoryAutoInstaller`. Downloads are only triggered from `EnsureInstalledAsync` — never from a bare `ResolveCommandAsync` call.
+
+Cache location: `~/.memorylens/tools/dotmemory/{version}/`
+
+Multiple versions coexist in the cache. A `current.txt` file in `~/.memorylens/tools/dotmemory/` points to the active version directory.
+
+---
+
+## Section 2: Platform Mapping
+
+Runtime detection uses `RuntimeInformation.OSArchitecture` + `OperatingSystem.Is*()`:
+
+| Runtime              | NuGet package suffix   |
+|----------------------|------------------------|
+| Windows x64          | `windows-x64`          |
+| Windows x86          | `windows-x86`          |
+| Windows ARM64        | `windows-arm64`        |
+| Linux x64            | `linux-x64`            |
+| Linux ARM64          | `linux-arm64`          |
+| Linux ARM            | `linux-arm`            |
+| Linux musl x64       | `linux-musl-x64`       |
+| Linux musl ARM64     | `linux-musl-arm64`     |
+| macOS x64            | `macos-x64`            |
+| macOS ARM64          | `macos-arm64`          |
+
+musl detection: check for `/lib/ld-musl-x86_64.so.1` (x64) or `/lib/ld-musl-aarch64.so.1` (ARM64) — standard approach since .NET does not expose this via `RuntimeInformation`.
+
+Platforms not in the table (e.g. FreeBSD, win-x86 if ever dropped by JetBrains) return `null` from `ResolveAutoInstalledAsync` and fall through to the existing discovery chain. The README documents supported platforms and directs unsupported ones to `DOTMEMORY_PATH`.
+
+---
+
+## Section 3: Download & Extraction
+
+NuGet packages are ZIP files. The flow inside `InstallLatestAsync`:
+
+1. Query latest version from NuGet v3 flat container API:
+   `https://api.nuget.org/v3-flatcontainer/jetbrains.dotmemory.console.{rid}/index.json`
+2. Download `.nupkg` to a temp file:
+   `https://api.nuget.org/v3-flatcontainer/jetbrains.dotmemory.console.{rid}/{version}/jetbrains.dotmemory.console.{rid}.{version}.nupkg`
+3. Extract into `~/.memorylens/tools/dotmemory/{version}/` using `ZipFile.ExtractToDirectory`
+4. Locate the executable under `tools/` inside the extracted package
+5. On Linux/macOS, set executable permission via `File.SetUnixFileMode`
+6. Write `current.txt` pointing to the new version directory
+
+If extraction is interrupted, the version directory is deleted before retrying to avoid serving a corrupt binary.
+
+---
+
+## Section 4: Version Management
+
+- **`EnsureInstalledAsync`**: always queries NuGet for the latest version. If newer than cached, downloads alongside the old version, then updates `current.txt` atomically. Old version directories are left in place — not auto-deleted.
+- **`ResolveAutoInstalledAsync`**: reads `current.txt` to find the active binary — no network call.
+- Future cleanup is out of scope for this iteration (can be a `clean_dotmemory` MCP tool or CLI flag).
+
+---
+
+## Section 5: Error Handling
+
+All error scenarios must be documented in the README.
+
+| Scenario | Behaviour |
+|---|---|
+| No internet / NuGet unreachable | `EnsureInstalledAsync` catches `HttpRequestException`, returns `ToolStatus(false)` with message suggesting `DOTMEMORY_PATH`. Falls through to existing discovery modes. |
+| Unsupported platform | Returns `ToolStatus(false)` naming the platform and linking to README manual setup section. |
+| Partial/corrupt extraction | Detected by checking executable exists after extraction. Delete version directory, retry once. On second failure, fall through to existing discovery modes. |
+| `chmod +x` failure | Surfaced as a clear error — do not silently return a non-executable binary. |
+| Cancellation | `OperationCanceledException` always re-thrown, never swallowed. |
+
+---
+
+## Section 6: Testing
+
+`DotMemoryAutoInstaller` is hidden behind `IDotMemoryAutoInstaller`:
+
+```csharp
+public interface IDotMemoryAutoInstaller
+{
+    Task<string?> GetCachedPathAsync(CancellationToken ct);
+    Task<string?> InstallLatestAsync(CancellationToken ct);
+    string? GetUnsupportedPlatformMessage();
+}
+```
+
+Unit test coverage:
+
+- `ResolveAutoInstalledAsync` returns cached path when `GetCachedPathAsync` returns a value
+- `EnsureInstalledAsync` calls `InstallLatestAsync` when cache is empty
+- `EnsureInstalledAsync` falls through gracefully when `InstallLatestAsync` returns `null`
+- `EnsureInstalledAsync` returns unsupported platform message correctly
+- `DotMemoryAutoInstaller` platform mapping (no I/O)
+- `DotMemoryAutoInstaller` musl detection logic
+
+The real `DotMemoryAutoInstaller` (HTTP + filesystem) is excluded from CI unit tests — it requires network access and is covered by manual integration testing.
+
+---
+
+## Out of Scope
+
+- Cache cleanup / `clean_dotmemory` tool
+- Version pinning via config
+- Proxy support for NuGet downloads
+- Offline/airgap installs (use `DOTMEMORY_PATH`)

--- a/docs/plans/2026-04-14-dotmemory-auto-install-plan.md
+++ b/docs/plans/2026-04-14-dotmemory-auto-install-plan.md
@@ -1,0 +1,937 @@
+# dotMemory Auto-Install Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Automatically download and cache the correct `JetBrains.dotMemory.Console.*` NuGet package on first `ensure_dotmemory` call, so dotMemory works out of the box with zero user setup.
+
+**Architecture:** A new `IDotMemoryAutoInstaller` / `DotMemoryAutoInstaller` class handles platform detection, NuGet download, ZIP extraction, and cache management under `~/.memorylens/tools/dotmemory/`. `DotMemoryToolManager` gains a new `ResolveAutoInstalledAsync` step (position: after DOTMEMORY_PATH, before PATH discovery) and calls `InstallLatestAsync` from `EnsureInstalledAsync` when the cache is empty.
+
+**Tech Stack:** .NET 10, `System.IO.Compression.ZipFile`, `HttpClient`, `System.Runtime.InteropServices.RuntimeInformation`, xUnit
+
+---
+
+### Task 1: Interface + Fake
+
+**Files:**
+- Create: `src/MemoryLens.Mcp/Profiler/IDotMemoryAutoInstaller.cs`
+- Create: `tests/MemoryLens.Mcp.Tests/Profiler/FakeDotMemoryAutoInstaller.cs`
+
+**Step 1: Create the interface**
+
+```csharp
+// src/MemoryLens.Mcp/Profiler/IDotMemoryAutoInstaller.cs
+namespace MemoryLens.Mcp.Profiler;
+
+public interface IDotMemoryAutoInstaller
+{
+    /// <summary>Returns the path to the cached dotMemory executable, or null if not cached.</summary>
+    Task<string?> GetCachedPathAsync(CancellationToken ct);
+
+    /// <summary>Downloads and caches the latest dotMemory for the current platform.
+    /// Returns the executable path on success, null on failure (network error, unsupported platform).</summary>
+    Task<string?> InstallLatestAsync(CancellationToken ct);
+
+    /// <summary>Returns a human-readable message if the current platform is not supported by
+    /// JetBrains dotMemory Console, or null if the platform is supported.</summary>
+    string? GetUnsupportedPlatformMessage();
+}
+```
+
+**Step 2: Create the fake**
+
+```csharp
+// tests/MemoryLens.Mcp.Tests/Profiler/FakeDotMemoryAutoInstaller.cs
+namespace MemoryLens.Mcp.Tests.Profiler;
+
+public class FakeDotMemoryAutoInstaller(
+    string? cachedPath = null,
+    string? installPath = null,
+    string? unsupportedMessage = null) : IDotMemoryAutoInstaller
+{
+    public Task<string?> GetCachedPathAsync(CancellationToken ct) =>
+        Task.FromResult(cachedPath);
+
+    public Task<string?> InstallLatestAsync(CancellationToken ct) =>
+        Task.FromResult(installPath);
+
+    public string? GetUnsupportedPlatformMessage() => unsupportedMessage;
+}
+```
+
+**Step 3: Build to verify no compile errors**
+
+```bash
+dotnet build src/MemoryLens.Mcp/MemoryLens.Mcp.csproj -c Release --nologo -q
+dotnet build tests/MemoryLens.Mcp.Tests/MemoryLens.Mcp.Tests.csproj -c Release --nologo -q
+```
+
+Expected: no errors.
+
+**Step 4: Commit**
+
+```bash
+git add src/MemoryLens.Mcp/Profiler/IDotMemoryAutoInstaller.cs
+git add tests/MemoryLens.Mcp.Tests/Profiler/FakeDotMemoryAutoInstaller.cs
+git commit -m "feat: add IDotMemoryAutoInstaller interface and fake"
+```
+
+---
+
+### Task 2: Wire IDotMemoryAutoInstaller into DotMemoryToolManager
+
+**Files:**
+- Modify: `src/MemoryLens.Mcp/Profiler/DotMemoryToolManager.cs`
+- Modify: `src/MemoryLens.Mcp/Program.cs`
+- Modify: `tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryToolManagerTests.cs`
+
+**Step 1: Write failing tests for new wiring**
+
+Add to `DotMemoryToolManagerTests.cs`:
+
+```csharp
+[Fact]
+public async Task ResolveCommand_ReturnsAutoInstalled_WhenCacheHit()
+{
+    var tempFile = Path.GetTempFileName();
+    try
+    {
+        var autoInstaller = new FakeDotMemoryAutoInstaller(cachedPath: tempFile);
+        var manager = new DotMemoryToolManager(new FakeProcessRunner(exitCode: 1, output: ""), autoInstaller);
+
+        var command = await manager.ResolveCommandAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(command);
+        Assert.Equal(tempFile, command.FileName);
+        Assert.Equal(DotMemoryCommandKind.AutoInstalled, command.Kind);
+    }
+    finally
+    {
+        File.Delete(tempFile);
+    }
+}
+
+[Fact]
+public async Task EnsureInstalled_CallsInstallLatest_WhenCacheMiss()
+{
+    var tempFile = Path.GetTempFileName();
+    try
+    {
+        var autoInstaller = new FakeDotMemoryAutoInstaller(cachedPath: null, installPath: tempFile);
+        var manager = new DotMemoryToolManager(new FakeProcessRunner(exitCode: 1, output: ""), autoInstaller);
+
+        var result = await manager.EnsureInstalledAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsInstalled);
+        Assert.Equal(DotMemoryCommandKind.AutoInstalled, result.Kind);
+    }
+    finally
+    {
+        File.Delete(tempFile);
+    }
+}
+
+[Fact]
+public async Task EnsureInstalled_FallsThrough_WhenInstallLatestFails()
+{
+    var autoInstaller = new FakeDotMemoryAutoInstaller(cachedPath: null, installPath: null);
+    var runner = new FakeProcessRunner(exitCode: 1, output: "");
+    var manager = new DotMemoryToolManager(runner, autoInstaller);
+
+    var result = await manager.EnsureInstalledAsync(TestContext.Current.CancellationToken);
+
+    Assert.False(result.IsInstalled);
+}
+
+[Fact]
+public async Task EnsureInstalled_ReturnsUnsupportedMessage_WhenPlatformNotSupported()
+{
+    var autoInstaller = new FakeDotMemoryAutoInstaller(
+        unsupportedMessage: "Platform freebsd-x64 is not supported.");
+    var runner = new FakeProcessRunner(exitCode: 1, output: "");
+    var manager = new DotMemoryToolManager(runner, autoInstaller);
+
+    var result = await manager.EnsureInstalledAsync(TestContext.Current.CancellationToken);
+
+    Assert.False(result.IsInstalled);
+    Assert.Contains("freebsd-x64", result.Message);
+}
+```
+
+Note: `ToolStatus` needs a `Kind` property — add `DotMemoryCommandKind? Kind` to the record.
+
+**Step 2: Run tests to verify they fail**
+
+```bash
+dotnet test tests/MemoryLens.Mcp.Tests -c Release --nologo -q
+```
+
+Expected: compilation errors / failures on the new tests.
+
+**Step 3: Add `DotMemoryCommandKind.AutoInstalled` to the enum**
+
+In `DotMemoryToolManager.cs`, add `AutoInstalled` to the enum:
+
+```csharp
+public enum DotMemoryCommandKind
+{
+    AutoInstalled,   // add this
+    ExplicitPath,
+    PathDiscovery,
+    LocalTool,
+    GlobalTool
+}
+```
+
+**Step 4: Add `Kind` to `ToolStatus`**
+
+```csharp
+public record ToolStatus(bool IsInstalled, string? Version, string Message, DotMemoryCommandKind? Kind = null);
+```
+
+**Step 5: Add `IDotMemoryAutoInstaller` parameter to `DotMemoryToolManager`**
+
+Change the class declaration from:
+```csharp
+public class DotMemoryToolManager(IProcessRunner processRunner)
+```
+to:
+```csharp
+public class DotMemoryToolManager(IProcessRunner processRunner, IDotMemoryAutoInstaller? autoInstaller = null)
+```
+
+**Step 6: Add `ResolveAutoInstalledAsync` and wire it into `ResolveCommandAsync`**
+
+Add the new method:
+
+```csharp
+private async Task<DotMemoryCommand?> ResolveAutoInstalledAsync(CancellationToken ct)
+{
+    if (autoInstaller is null)
+        return null;
+
+    var path = await autoInstaller.GetCachedPathAsync(ct).ConfigureAwait(false);
+    if (path is null)
+        return null;
+
+    return new DotMemoryCommand(
+        path,
+        "",
+        $"auto-installed dotMemory ({path})",
+        null,
+        DotMemoryCommandKind.AutoInstalled);
+}
+```
+
+In `ResolveCommandAsync`, insert the call after `ResolveConfiguredPath` and before `ResolveFromPathAsync`:
+
+```csharp
+public virtual async Task<DotMemoryCommand?> ResolveCommandAsync(CancellationToken ct = default)
+{
+    if (_cachedCommand is not null)
+        return _cachedCommand;
+
+    var configured = ResolveConfiguredPath();
+    if (configured is not null) { _cachedCommand = configured; return configured; }
+
+    var autoInstalled = await ResolveAutoInstalledAsync(ct).ConfigureAwait(false);
+    if (autoInstalled is not null) { _cachedCommand = autoInstalled; return autoInstalled; }
+
+    var fromPath = await ResolveFromPathAsync(ct).ConfigureAwait(false);
+    if (fromPath is not null) { _cachedCommand = fromPath; return fromPath; }
+
+    var localTool = await ResolveLocalToolAsync(ct).ConfigureAwait(false);
+    if (localTool is not null) { _cachedCommand = localTool; return localTool; }
+
+    var globalTool = await ResolveGlobalToolAsync(ct).ConfigureAwait(false);
+    _cachedCommand = globalTool;
+    return globalTool;
+}
+```
+
+**Step 7: Wire `InstallLatestAsync` into `EnsureInstalledAsync`**
+
+Replace the start of `EnsureInstalledAsync` so that after the command is not found via `ResolveCommandAsync`, we try auto-install before falling back to legacy `dotnet tool install`:
+
+```csharp
+public async Task<ToolStatus> EnsureInstalledAsync(CancellationToken ct = default)
+{
+    InvalidateCache();
+    var command = await ResolveCommandAsync(ct).ConfigureAwait(false);
+    if (command is not null)
+    {
+        if (command.Kind == DotMemoryCommandKind.GlobalTool)
+        {
+            var globalToolResult = await TryRunAsync("dotnet", "tool list -g", ct).ConfigureAwait(false);
+            if (globalToolResult is not null && globalToolResult.ExitCode == 0 && ContainsTool(globalToolResult.Output))
+            {
+                var version = ParseVersion(globalToolResult.Output);
+                await processRunner.RunAsync("dotnet", "tool update -g dotnet-dotmemory", ct).ConfigureAwait(false);
+                return new ToolStatus(true, version, $"dotnet-dotmemory {version} is installed.", DotMemoryCommandKind.GlobalTool);
+            }
+        }
+
+        return new ToolStatus(
+            true,
+            string.IsNullOrWhiteSpace(command.Version) ? null : command.Version,
+            $"{command.DisplayName} is available.",
+            command.Kind);
+    }
+
+    // Try auto-install before legacy fallback
+    if (autoInstaller is not null)
+    {
+        var unsupportedMsg = autoInstaller.GetUnsupportedPlatformMessage();
+
+        var autoPath = await autoInstaller.InstallLatestAsync(ct).ConfigureAwait(false);
+        if (autoPath is not null)
+        {
+            InvalidateCache();
+            command = await ResolveCommandAsync(ct).ConfigureAwait(false);
+            if (command is not null)
+                return new ToolStatus(true, command.Version, $"{command.DisplayName} is available.", command.Kind);
+        }
+
+        if (unsupportedMsg is not null)
+            return new ToolStatus(false, null, unsupportedMsg);
+    }
+
+    // Legacy compatibility path
+    var installResult = await processRunner
+        .RunAsync("dotnet", "tool install -g dotnet-dotmemory", ct)
+        .ConfigureAwait(false);
+
+    if (installResult.ExitCode != 0)
+    {
+        var errorMessage = "dotMemory CLI was not found. " +
+            "Set DOTMEMORY_PATH to dotMemory.exe/dotMemory.sh, " +
+            "put dotMemory in PATH, or install dotnet-dotmemory.";
+
+        if (!string.IsNullOrWhiteSpace(installResult.Error))
+            errorMessage += $" Details: {installResult.Error}";
+
+        return new ToolStatus(false, null, errorMessage);
+    }
+
+    command = await ResolveCommandAsync(ct).ConfigureAwait(false);
+    if (command is not null)
+        return new ToolStatus(true, command.Version, $"{command.DisplayName} is available.", command.Kind);
+
+    return new ToolStatus(false, null,
+        "dotnet-dotmemory was installed, but the executable could not be resolved. " +
+        "Add the .NET tools directory to PATH or set DOTMEMORY_PATH explicitly.");
+}
+```
+
+**Step 8: Register `IDotMemoryAutoInstaller` in DI**
+
+In `Program.cs`, add before `AddSingleton<DotMemoryToolManager>`:
+
+```csharp
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton<IDotMemoryAutoInstaller, DotMemoryAutoInstaller>();
+```
+
+(This will fail to compile until `DotMemoryAutoInstaller` exists — that's fine, leave a `// TODO` comment and add it in Task 3.)
+
+**Step 9: Run tests**
+
+```bash
+dotnet test tests/MemoryLens.Mcp.Tests -c Release --nologo -q
+```
+
+Expected: all 86 existing tests pass + 4 new tests pass.
+
+**Step 10: Commit**
+
+```bash
+git add src/MemoryLens.Mcp/Profiler/DotMemoryToolManager.cs
+git add src/MemoryLens.Mcp/Program.cs
+git add tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryToolManagerTests.cs
+git commit -m "feat: wire IDotMemoryAutoInstaller into DotMemoryToolManager"
+```
+
+---
+
+### Task 3: DotMemoryAutoInstaller — Platform Mapping
+
+**Files:**
+- Create: `src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs`
+- Create: `tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryAutoInstallerTests.cs`
+
+**Step 1: Write failing tests for platform mapping**
+
+```csharp
+// tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryAutoInstallerTests.cs
+using MemoryLens.Mcp.Profiler;
+using Xunit;
+
+namespace MemoryLens.Mcp.Tests.Profiler;
+
+public class DotMemoryAutoInstallerTests
+{
+    [Fact]
+    public void GetRid_ReturnsNonNull_OnCurrentPlatform()
+    {
+        var rid = DotMemoryAutoInstaller.GetRid();
+        Assert.NotNull(rid);
+    }
+
+    [Theory]
+    [InlineData(false, false, "linux-x64")]
+    [InlineData(true, false, "linux-musl-x64")]
+    public void IsMusl_AffectsLinuxRid(bool hasMuslFile, bool isArm64, string expectedSuffix)
+    {
+        // This tests the logic branching — actual file detection tested via GetRid()
+        var rid = DotMemoryAutoInstaller.BuildLinuxRid(isArm64: isArm64, isMusl: hasMuslFile);
+        Assert.Equal(expectedSuffix, rid);
+    }
+
+    [Theory]
+    [InlineData(false, false, "linux-x64")]
+    [InlineData(false, true, "linux-arm64")]
+    [InlineData(true, false, "linux-musl-x64")]
+    [InlineData(true, true, "linux-musl-arm64")]
+    public void BuildLinuxRid_ReturnsCorrectSuffix(bool isMusl, bool isArm64, string expected)
+    {
+        Assert.Equal(expected, DotMemoryAutoInstaller.BuildLinuxRid(isArm64, isMusl));
+    }
+}
+```
+
+**Step 2: Run to verify they fail**
+
+```bash
+dotnet test tests/MemoryLens.Mcp.Tests -c Release --nologo -q --filter "DotMemoryAutoInstallerTests"
+```
+
+Expected: compilation error — `DotMemoryAutoInstaller` does not exist.
+
+**Step 3: Implement the class with platform mapping**
+
+```csharp
+// src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
+using System.Net.Http;
+using System.Runtime.InteropServices;
+
+namespace MemoryLens.Mcp.Profiler;
+
+public class DotMemoryAutoInstaller(HttpClient httpClient) : IDotMemoryAutoInstaller
+{
+    private static readonly string CacheRoot = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".memorylens", "tools", "dotmemory");
+
+    // --- Platform detection ---
+
+    public static string? GetRid()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return RuntimeInformation.OSArchitecture switch
+            {
+                Architecture.X64  => "windows-x64",
+                Architecture.X86  => "windows-x86",
+                Architecture.Arm64 => "windows-arm64",
+                _ => null
+            };
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            bool isArm64 = RuntimeInformation.OSArchitecture == Architecture.Arm64;
+            bool isArm   = RuntimeInformation.OSArchitecture == Architecture.Arm;
+            bool isMusl  = IsMusl();
+
+            if (isArm) return "linux-arm";
+            return BuildLinuxRid(isArm64, isMusl);
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return RuntimeInformation.OSArchitecture switch
+            {
+                Architecture.X64  => "macos-x64",
+                Architecture.Arm64 => "macos-arm64",
+                _ => null
+            };
+        }
+
+        return null;
+    }
+
+    public static string BuildLinuxRid(bool isArm64, bool isMusl)
+    {
+        var arch = isArm64 ? "arm64" : "x64";
+        return isMusl ? $"linux-musl-{arch}" : $"linux-{arch}";
+    }
+
+    internal static bool IsMusl() =>
+        File.Exists("/lib/ld-musl-x86_64.so.1") ||
+        File.Exists("/lib/ld-musl-aarch64.so.1");
+
+    public string? GetUnsupportedPlatformMessage()
+    {
+        if (GetRid() is not null)
+            return null;
+
+        var current = $"{RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture})";
+        return $"Platform '{current}' is not supported by JetBrains dotMemory Console. " +
+               "Set DOTMEMORY_PATH to point to your dotMemory installation. " +
+               "See README for details.";
+    }
+
+    // Stubs — implemented in Task 4 and 5
+    public Task<string?> GetCachedPathAsync(CancellationToken ct) => Task.FromResult<string?>(null);
+    public Task<string?> InstallLatestAsync(CancellationToken ct) => Task.FromResult<string?>(null);
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+dotnet test tests/MemoryLens.Mcp.Tests -c Release --nologo -q --filter "DotMemoryAutoInstallerTests"
+```
+
+Expected: all new platform mapping tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
+git add tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryAutoInstallerTests.cs
+git commit -m "feat: add DotMemoryAutoInstaller with platform mapping"
+```
+
+---
+
+### Task 4: DotMemoryAutoInstaller — Cache Reading
+
+**Files:**
+- Modify: `src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs`
+- Modify: `tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryAutoInstallerTests.cs`
+
+**Step 1: Write failing tests**
+
+Add to `DotMemoryAutoInstallerTests`:
+
+```csharp
+[Fact]
+public async Task GetCachedPath_ReturnsNull_WhenNoCacheDir()
+{
+    var installer = new DotMemoryAutoInstaller(new HttpClient(), cacheRoot: Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+    var result = await installer.GetCachedPathAsync(TestContext.Current.CancellationToken);
+    Assert.Null(result);
+}
+
+[Fact]
+public async Task GetCachedPath_ReturnsNull_WhenCurrentTxtMissing()
+{
+    var cacheRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+    Directory.CreateDirectory(cacheRoot);
+    try
+    {
+        var installer = new DotMemoryAutoInstaller(new HttpClient(), cacheRoot);
+        var result = await installer.GetCachedPathAsync(TestContext.Current.CancellationToken);
+        Assert.Null(result);
+    }
+    finally { Directory.Delete(cacheRoot, recursive: true); }
+}
+
+[Fact]
+public async Task GetCachedPath_ReturnsPath_WhenExecutableExists()
+{
+    var cacheRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+    var versionDir = Path.Combine(cacheRoot, "2026.1.0");
+    var toolsDir = Path.Combine(versionDir, "tools");
+    Directory.CreateDirectory(toolsDir);
+
+    var exeName = OperatingSystem.IsWindows() ? "dotMemory.exe" : "dotMemory.sh";
+    var exePath = Path.Combine(toolsDir, exeName);
+    File.WriteAllText(exePath, "fake");
+    await File.WriteAllTextAsync(Path.Combine(cacheRoot, "current.txt"), "2026.1.0");
+
+    try
+    {
+        var installer = new DotMemoryAutoInstaller(new HttpClient(), cacheRoot);
+        var result = await installer.GetCachedPathAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(exePath, result);
+    }
+    finally { Directory.Delete(cacheRoot, recursive: true); }
+}
+```
+
+Note: `DotMemoryAutoInstaller` needs a `cacheRoot` parameter for testing (injected, not hardcoded).
+
+**Step 2: Run to verify they fail**
+
+```bash
+dotnet test tests/MemoryLens.Mcp.Tests -c Release --nologo -q --filter "GetCachedPath"
+```
+
+**Step 3: Implement `GetCachedPathAsync` and `FindExecutable`**
+
+Update `DotMemoryAutoInstaller` to accept `cacheRoot` as an optional parameter (default is `~/.memorylens/tools/dotmemory`):
+
+```csharp
+public class DotMemoryAutoInstaller(HttpClient httpClient, string? cacheRoot = null) : IDotMemoryAutoInstaller
+{
+    private readonly string _cacheRoot = cacheRoot ?? Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".memorylens", "tools", "dotmemory");
+
+    public async Task<string?> GetCachedPathAsync(CancellationToken ct)
+    {
+        var currentFile = Path.Combine(_cacheRoot, "current.txt");
+        if (!File.Exists(currentFile))
+            return null;
+
+        var version = (await File.ReadAllTextAsync(currentFile, ct).ConfigureAwait(false)).Trim();
+        var versionDir = Path.Combine(_cacheRoot, version);
+        var exePath = FindExecutable(versionDir);
+        return exePath is not null && File.Exists(exePath) ? exePath : null;
+    }
+
+    private static string? FindExecutable(string versionDir)
+    {
+        var toolsDir = Path.Combine(versionDir, "tools");
+        if (!Directory.Exists(toolsDir))
+            return null;
+
+        var candidates = OperatingSystem.IsWindows()
+            ? new[] { "dotMemory.exe" }
+            : new[] { "dotMemory.sh", "dotMemory" };
+
+        foreach (var name in candidates)
+        {
+            var path = Path.Combine(toolsDir, name);
+            if (File.Exists(path))
+                return path;
+        }
+
+        return null;
+    }
+}
+```
+
+**Step 4: Run tests**
+
+```bash
+dotnet test tests/MemoryLens.Mcp.Tests -c Release --nologo -q --filter "GetCachedPath"
+```
+
+Expected: all 3 new tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
+git add tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryAutoInstallerTests.cs
+git commit -m "feat: implement GetCachedPathAsync in DotMemoryAutoInstaller"
+```
+
+---
+
+### Task 5: DotMemoryAutoInstaller — Download & Install
+
+**Files:**
+- Modify: `src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs`
+- Modify: `tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryAutoInstallerTests.cs`
+
+**Step 1: Write failing tests**
+
+Add to `DotMemoryAutoInstallerTests`:
+
+```csharp
+[Fact]
+public async Task InstallLatest_ReturnsNull_WhenPlatformUnsupported()
+{
+    // Use a subclass that reports unsupported platform
+    var installer = new UnsupportedPlatformInstaller(new HttpClient());
+    var result = await installer.InstallLatestAsync(TestContext.Current.CancellationToken);
+    Assert.Null(result);
+}
+
+[Fact]
+public async Task FetchLatestVersion_ReturnsVersion_FromJson()
+{
+    var json = """{"versions":["2025.3.0","2026.1.0"]}""";
+    var http = new HttpClient(new FakeHttpMessageHandler(json));
+    var installer = new DotMemoryAutoInstaller(http, Path.GetTempPath());
+
+    var version = await installer.FetchLatestVersionAsync("jetbrains.dotmemory.console.windows-x64", CancellationToken.None);
+
+    Assert.Equal("2026.1.0", version);
+}
+
+// Helper for FakeHttpMessageHandler in tests/MemoryLens.Mcp.Tests/Profiler/FakeHttpMessageHandler.cs:
+// public class FakeHttpMessageHandler(string responseBody, HttpStatusCode statusCode = HttpStatusCode.OK)
+//     : HttpMessageHandler
+// {
+//     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+//         => Task.FromResult(new HttpResponseMessage(statusCode) { Content = new StringContent(responseBody) });
+// }
+```
+
+**Step 2: Create `FakeHttpMessageHandler`**
+
+```csharp
+// tests/MemoryLens.Mcp.Tests/Profiler/FakeHttpMessageHandler.cs
+using System.Net;
+using System.Net.Http;
+
+namespace MemoryLens.Mcp.Tests.Profiler;
+
+public class FakeHttpMessageHandler(string responseBody, HttpStatusCode statusCode = HttpStatusCode.OK)
+    : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+        Task.FromResult(new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(responseBody)
+        });
+}
+```
+
+**Step 3: Run to verify they fail**
+
+```bash
+dotnet test tests/MemoryLens.Mcp.Tests -c Release --nologo -q --filter "InstallLatest|FetchLatest"
+```
+
+**Step 4: Implement `FetchLatestVersionAsync` and `InstallLatestAsync`**
+
+Replace the `InstallLatestAsync` and `GetCachedPathAsync` stubs in `DotMemoryAutoInstaller.cs` with:
+
+```csharp
+public async Task<string?> InstallLatestAsync(CancellationToken ct)
+{
+    var rid = GetRid();
+    if (rid is null)
+        return null;
+
+    var packageId = $"jetbrains.dotmemory.console.{rid}";
+
+    string? version;
+    try
+    {
+        version = await FetchLatestVersionAsync(packageId, ct).ConfigureAwait(false);
+    }
+    catch (OperationCanceledException) { throw; }
+    catch { return null; }
+
+    if (version is null)
+        return null;
+
+    var versionDir = Path.Combine(_cacheRoot, version);
+
+    if (!Directory.Exists(versionDir))
+    {
+        try
+        {
+            await DownloadAndExtractAsync(packageId, version, versionDir, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch
+        {
+            if (Directory.Exists(versionDir))
+                Directory.Delete(versionDir, recursive: true);
+            return null;
+        }
+    }
+
+    var exePath = FindExecutable(versionDir);
+    if (exePath is null || !File.Exists(exePath))
+    {
+        Directory.Delete(versionDir, recursive: true);
+        return null;
+    }
+
+    try { await MakeExecutableAsync(exePath).ConfigureAwait(false); }
+    catch (OperationCanceledException) { throw; }
+    catch { return null; } // chmod failure — can't execute
+
+    Directory.CreateDirectory(_cacheRoot);
+    await File.WriteAllTextAsync(Path.Combine(_cacheRoot, "current.txt"), version, ct).ConfigureAwait(false);
+
+    return exePath;
+}
+
+internal async Task<string?> FetchLatestVersionAsync(string packageId, CancellationToken ct)
+{
+    var url = $"https://api.nuget.org/v3-flatcontainer/{packageId}/index.json";
+    var json = await httpClient.GetStringAsync(url, ct).ConfigureAwait(false);
+    using var doc = System.Text.Json.JsonDocument.Parse(json);
+    var versions = doc.RootElement.GetProperty("versions");
+    var last = versions[versions.GetArrayLength() - 1].GetString();
+    return last;
+}
+
+private async Task DownloadAndExtractAsync(string packageId, string version, string versionDir, CancellationToken ct)
+{
+    var url = $"https://api.nuget.org/v3-flatcontainer/{packageId}/{version}/{packageId}.{version}.nupkg";
+    var tempFile = Path.GetTempFileName();
+    try
+    {
+        using var response = await httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        await using var fs = File.Create(tempFile);
+        await stream.CopyToAsync(fs, ct).ConfigureAwait(false);
+        fs.Close();
+
+        Directory.CreateDirectory(versionDir);
+        System.IO.Compression.ZipFile.ExtractToDirectory(tempFile, versionDir, overwriteFiles: true);
+    }
+    finally
+    {
+        File.Delete(tempFile);
+    }
+}
+
+private static Task MakeExecutableAsync(string path)
+{
+    if (OperatingSystem.IsWindows())
+        return Task.CompletedTask;
+
+    File.SetUnixFileMode(path,
+        UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+        UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+        UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+    return Task.CompletedTask;
+}
+```
+
+**Step 5: Run tests**
+
+```bash
+dotnet test tests/MemoryLens.Mcp.Tests -c Release --nologo -q
+```
+
+Expected: all tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
+git add tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryAutoInstallerTests.cs
+git add tests/MemoryLens.Mcp.Tests/Profiler/FakeHttpMessageHandler.cs
+git commit -m "feat: implement InstallLatestAsync with NuGet download and extraction"
+```
+
+---
+
+### Task 6: DI Registration + Full Build
+
+**Files:**
+- Modify: `src/MemoryLens.Mcp/Program.cs`
+
+**Step 1: Register `DotMemoryAutoInstaller` and `HttpClient`**
+
+Replace the `// TODO` comment and update `Program.cs`:
+
+```csharp
+builder.Services.AddHttpClient<DotMemoryAutoInstaller>();
+builder.Services.AddSingleton<IDotMemoryAutoInstaller, DotMemoryAutoInstaller>();
+```
+
+Add above the existing `AddSingleton<DotMemoryToolManager>()` line.
+
+**Step 2: Build and run all tests**
+
+```bash
+dotnet build src/MemoryLens.Mcp/MemoryLens.Mcp.csproj -c Release --nologo -q
+dotnet test tests/MemoryLens.Mcp.Tests -c Release --nologo -q
+```
+
+Expected: build succeeds, all tests pass.
+
+**Step 3: Commit**
+
+```bash
+git add src/MemoryLens.Mcp/Program.cs
+git commit -m "feat: register DotMemoryAutoInstaller in DI"
+```
+
+---
+
+### Task 7: README Documentation
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Add a "dotMemory CLI" section to README**
+
+After the existing Prerequisites section, add:
+
+```markdown
+## dotMemory CLI
+
+MemoryLens MCP automatically downloads the official JetBrains dotMemory Console CLI on first use
+by calling the `ensure_dotmemory` MCP tool. No manual setup required on supported platforms.
+
+### Supported Platforms (auto-download)
+
+| Platform        | Architecture       |
+|-----------------|--------------------|
+| Windows         | x64, x86, ARM64    |
+| Linux (glibc)   | x64, ARM64, ARM    |
+| Linux (musl)    | x64, ARM64         |
+| macOS           | x64 (Intel), ARM64 (Apple Silicon) |
+
+### Unsupported Platforms
+
+Platforms not listed above (e.g. FreeBSD, Linux x86) cannot use auto-download.
+Set `DOTMEMORY_PATH` to point to your dotMemory installation instead:
+
+```bash
+export DOTMEMORY_PATH="/path/to/dotMemory.sh"   # Linux/macOS
+set DOTMEMORY_PATH=C:\path\to\dotMemory.exe      # Windows
+```
+
+Find your dotMemory CLI in your JetBrains Toolbox installation:
+- **Linux:** `~/.local/share/JetBrains/Toolbox/apps/rider/tools/profiler/dotMemory.sh`
+- **Windows:** `%LOCALAPPDATA%\JetBrains\Toolbox\apps\rider\tools\profiler\dotMemory.exe`
+
+### Error Scenarios
+
+| Error | Cause | Fix |
+|---|---|---|
+| `Platform '...' is not supported` | Unsupported OS/arch | Set `DOTMEMORY_PATH` |
+| `Failed to download dotMemory` | No internet / NuGet unreachable | Set `DOTMEMORY_PATH` or retry |
+| `chmod +x failed` | Read-only filesystem | Set `DOTMEMORY_PATH` to a writable location |
+| `dotMemory CLI not found` | All discovery modes failed | Run `ensure_dotmemory` or set `DOTMEMORY_PATH` |
+
+### Cache Location
+
+Downloaded binaries are cached at `~/.memorylens/tools/dotmemory/{version}/`.
+Old versions are not auto-removed. Delete the directory manually to free disk space.
+```
+
+**Step 2: Run full test suite one final time**
+
+```bash
+dotnet test tests/MemoryLens.Mcp.Tests -c Release --nologo -q
+```
+
+Expected: all tests pass.
+
+**Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: document dotMemory auto-install, supported platforms, and error scenarios"
+```
+
+---
+
+### Task 8: Open PR
+
+```bash
+git push origin fix/pr41-dotmemory-path
+gh pr create \
+  --base main \
+  --title "feat: auto-download JetBrains dotMemory Console on first use" \
+  --body "Automatically downloads the correct JetBrains.dotMemory.Console NuGet package on first \`ensure_dotmemory\` call. Zero user setup on Windows, Linux (glibc/musl), and macOS. Unsupported platforms fall back to DOTMEMORY_PATH with clear guidance."
+```

--- a/src/MemoryLens.Mcp/MemoryLens.Mcp.csproj
+++ b/src/MemoryLens.Mcp/MemoryLens.Mcp.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
   </ItemGroup>
 

--- a/src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
+++ b/src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
@@ -102,6 +102,7 @@ public class DotMemoryAutoInstaller(HttpClient httpClient, string? cacheRoot = n
 
     // --- Download & install ---
 
+    // Not thread-safe: concurrent calls to the same cache root may corrupt extraction.
     public async Task<string?> InstallLatestAsync(CancellationToken ct)
     {
         var rid = GetRid();
@@ -155,14 +156,16 @@ public class DotMemoryAutoInstaller(HttpClient httpClient, string? cacheRoot = n
         return exePath;
     }
 
-    public async Task<string?> FetchLatestVersionAsync(string packageId, CancellationToken ct)
+    internal async Task<string?> FetchLatestVersionAsync(string packageId, CancellationToken ct)
     {
         var url = $"https://api.nuget.org/v3-flatcontainer/{packageId}/index.json";
         var json = await httpClient.GetStringAsync(url, ct).ConfigureAwait(false);
         using var doc = System.Text.Json.JsonDocument.Parse(json);
         var versions = doc.RootElement.GetProperty("versions");
-        var last = versions[versions.GetArrayLength() - 1].GetString();
-        return last;
+        var length = versions.GetArrayLength();
+        if (length == 0)
+            return null;
+        return versions[length - 1].GetString();
     }
 
     private async Task DownloadAndExtractAsync(string packageId, string version, string versionDir, CancellationToken ct)

--- a/src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
+++ b/src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
@@ -124,31 +124,37 @@ public class DotMemoryAutoInstaller(HttpClient httpClient, string? cacheRoot = n
 
         var versionDir = Path.Combine(_cacheRoot, version);
 
-        if (!Directory.Exists(versionDir))
+        string? exePath = null;
+        for (var attempt = 0; attempt < 2 && exePath is null; attempt++)
         {
+            if (Directory.Exists(versionDir))
+                Directory.Delete(versionDir, recursive: true);
+
             try
             {
                 await DownloadAndExtractAsync(packageId, version, versionDir, ct).ConfigureAwait(false);
             }
             catch (OperationCanceledException) { throw; }
-            catch
-            {
-                if (Directory.Exists(versionDir))
-                    Directory.Delete(versionDir, recursive: true);
-                return null;
-            }
+            catch { continue; }
+
+            exePath = FindExecutable(versionDir);
         }
 
-        var exePath = FindExecutable(versionDir);
         if (exePath is null || !File.Exists(exePath))
         {
-            Directory.Delete(versionDir, recursive: true);
+            if (Directory.Exists(versionDir))
+                Directory.Delete(versionDir, recursive: true);
             return null;
         }
 
         try { await MakeExecutableAsync(exePath).ConfigureAwait(false); }
         catch (OperationCanceledException) { throw; }
-        catch { return null; }
+        catch
+        {
+            if (Directory.Exists(versionDir))
+                Directory.Delete(versionDir, recursive: true);
+            return null;
+        }
 
         Directory.CreateDirectory(_cacheRoot);
         await File.WriteAllTextAsync(Path.Combine(_cacheRoot, "current.txt"), version, ct).ConfigureAwait(false);

--- a/src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
+++ b/src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
@@ -1,0 +1,206 @@
+using System.Runtime.InteropServices;
+
+namespace MemoryLens.Mcp.Profiler;
+
+public class DotMemoryAutoInstaller(HttpClient httpClient, string? cacheRoot = null) : IDotMemoryAutoInstaller
+{
+    private readonly string _cacheRoot = cacheRoot ?? Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        ".memorylens", "tools", "dotmemory");
+
+    // --- Platform detection ---
+
+    public static string? GetRid()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return RuntimeInformation.OSArchitecture switch
+            {
+                Architecture.X64   => "windows-x64",
+                Architecture.X86   => "windows-x86",
+                Architecture.Arm64 => "windows-arm64",
+                _ => null
+            };
+        }
+
+        if (OperatingSystem.IsLinux())
+        {
+            if (RuntimeInformation.OSArchitecture == Architecture.Arm)
+                return "linux-arm";
+
+            bool isArm64 = RuntimeInformation.OSArchitecture == Architecture.Arm64;
+            return BuildLinuxRid(isArm64, IsMusl());
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return RuntimeInformation.OSArchitecture switch
+            {
+                Architecture.X64   => "macos-x64",
+                Architecture.Arm64 => "macos-arm64",
+                _ => null
+            };
+        }
+
+        return null;
+    }
+
+    public static string BuildLinuxRid(bool isArm64, bool isMusl)
+    {
+        var arch = isArm64 ? "arm64" : "x64";
+        return isMusl ? $"linux-musl-{arch}" : $"linux-{arch}";
+    }
+
+    internal static bool IsMusl() =>
+        File.Exists("/lib/ld-musl-x86_64.so.1") ||
+        File.Exists("/lib/ld-musl-aarch64.so.1");
+
+    public string? GetUnsupportedPlatformMessage()
+    {
+        if (GetRid() is not null)
+            return null;
+
+        var current = $"{RuntimeInformation.OSDescription} ({RuntimeInformation.OSArchitecture})";
+        return $"Platform '{current}' is not supported by JetBrains dotMemory Console. " +
+               "Set DOTMEMORY_PATH to point to your dotMemory installation. " +
+               "See README for details.";
+    }
+
+    // --- Cache reading ---
+
+    public async Task<string?> GetCachedPathAsync(CancellationToken ct)
+    {
+        var currentFile = Path.Combine(_cacheRoot, "current.txt");
+        if (!File.Exists(currentFile))
+            return null;
+
+        var version = (await File.ReadAllTextAsync(currentFile, ct).ConfigureAwait(false)).Trim();
+        var versionDir = Path.Combine(_cacheRoot, version);
+        var exePath = FindExecutable(versionDir);
+        return exePath is not null && File.Exists(exePath) ? exePath : null;
+    }
+
+    private static string? FindExecutable(string versionDir)
+    {
+        var toolsDir = Path.Combine(versionDir, "tools");
+        if (!Directory.Exists(toolsDir))
+            return null;
+
+        var candidates = OperatingSystem.IsWindows()
+            ? new[] { "dotMemory.exe" }
+            : new[] { "dotMemory.sh", "dotMemory" };
+
+        foreach (var name in candidates)
+        {
+            var path = Path.Combine(toolsDir, name);
+            if (File.Exists(path))
+                return path;
+        }
+
+        return null;
+    }
+
+    // --- Download & install ---
+
+    public async Task<string?> InstallLatestAsync(CancellationToken ct)
+    {
+        var rid = GetRid();
+        if (rid is null)
+            return null;
+
+        var packageId = $"jetbrains.dotmemory.console.{rid}";
+
+        string? version;
+        try
+        {
+            version = await FetchLatestVersionAsync(packageId, ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch { return null; }
+
+        if (version is null)
+            return null;
+
+        var versionDir = Path.Combine(_cacheRoot, version);
+
+        if (!Directory.Exists(versionDir))
+        {
+            try
+            {
+                await DownloadAndExtractAsync(packageId, version, versionDir, ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch
+            {
+                if (Directory.Exists(versionDir))
+                    Directory.Delete(versionDir, recursive: true);
+                return null;
+            }
+        }
+
+        var exePath = FindExecutable(versionDir);
+        if (exePath is null || !File.Exists(exePath))
+        {
+            Directory.Delete(versionDir, recursive: true);
+            return null;
+        }
+
+        try { await MakeExecutableAsync(exePath).ConfigureAwait(false); }
+        catch (OperationCanceledException) { throw; }
+        catch { return null; }
+
+        Directory.CreateDirectory(_cacheRoot);
+        await File.WriteAllTextAsync(Path.Combine(_cacheRoot, "current.txt"), version, ct).ConfigureAwait(false);
+
+        return exePath;
+    }
+
+    public async Task<string?> FetchLatestVersionAsync(string packageId, CancellationToken ct)
+    {
+        var url = $"https://api.nuget.org/v3-flatcontainer/{packageId}/index.json";
+        var json = await httpClient.GetStringAsync(url, ct).ConfigureAwait(false);
+        using var doc = System.Text.Json.JsonDocument.Parse(json);
+        var versions = doc.RootElement.GetProperty("versions");
+        var last = versions[versions.GetArrayLength() - 1].GetString();
+        return last;
+    }
+
+    private async Task DownloadAndExtractAsync(string packageId, string version, string versionDir, CancellationToken ct)
+    {
+        var url = $"https://api.nuget.org/v3-flatcontainer/{packageId}/{version}/{packageId}.{version}.nupkg";
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            using var response = await httpClient
+                .GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct)
+                .ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            await using var fs = File.Create(tempFile);
+            await stream.CopyToAsync(fs, ct).ConfigureAwait(false);
+            fs.Close();
+
+            Directory.CreateDirectory(versionDir);
+            System.IO.Compression.ZipFile.ExtractToDirectory(tempFile, versionDir, overwriteFiles: true);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+                File.Delete(tempFile);
+        }
+    }
+
+    private static Task MakeExecutableAsync(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return Task.CompletedTask;
+
+        File.SetUnixFileMode(path,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
+++ b/src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
@@ -179,10 +179,16 @@ public class DotMemoryAutoInstaller(HttpClient httpClient, string? cacheRoot = n
                 .ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
-            await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-            await using var fs = File.Create(tempFile);
-            await stream.CopyToAsync(fs, ct).ConfigureAwait(false);
-            fs.Close();
+            var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+            await using (stream.ConfigureAwait(false))
+            {
+                var fs = File.Create(tempFile);
+                await using (fs.ConfigureAwait(false))
+                {
+                    await stream.CopyToAsync(fs, ct).ConfigureAwait(false);
+                    await fs.FlushAsync(ct).ConfigureAwait(false);
+                }
+            }
 
             Directory.CreateDirectory(versionDir);
             System.IO.Compression.ZipFile.ExtractToDirectory(tempFile, versionDir, overwriteFiles: true);

--- a/src/MemoryLens.Mcp/Profiler/DotMemoryToolManager.cs
+++ b/src/MemoryLens.Mcp/Profiler/DotMemoryToolManager.cs
@@ -2,10 +2,11 @@
 
 namespace MemoryLens.Mcp.Profiler;
 
-public record ToolStatus(bool IsInstalled, string? Version, string Message);
+public record ToolStatus(bool IsInstalled, string? Version, string Message, DotMemoryCommandKind? Kind = null);
 
 public enum DotMemoryCommandKind
 {
+    AutoInstalled,
     ExplicitPath,
     PathDiscovery,
     LocalTool,
@@ -25,7 +26,7 @@ public sealed record DotMemoryCommand(
             : $"{ArgumentsPrefix} {arguments}";
 }
 
-public class DotMemoryToolManager(IProcessRunner processRunner)
+public class DotMemoryToolManager(IProcessRunner processRunner, IDotMemoryAutoInstaller? autoInstaller = null)
 {
     private static readonly string[] ConfiguredPathVariables =
     [
@@ -45,7 +46,6 @@ public class DotMemoryToolManager(IProcessRunner processRunner)
         var command = await ResolveCommandAsync(ct).ConfigureAwait(false);
         if (command is not null)
         {
-            // Only attempt global tool update when the resolved command is actually the global tool
             if (command.Kind == DotMemoryCommandKind.GlobalTool)
             {
                 var globalToolResult = await TryRunAsync("dotnet", "tool list -g", ct).ConfigureAwait(false);
@@ -54,17 +54,35 @@ public class DotMemoryToolManager(IProcessRunner processRunner)
                 {
                     var version = ParseVersion(globalToolResult.Output);
                     await processRunner.RunAsync("dotnet", "tool update -g dotnet-dotmemory", ct).ConfigureAwait(false);
-                    return new ToolStatus(true, version, $"dotnet-dotmemory {version} is installed.");
+                    return new ToolStatus(true, version, $"dotnet-dotmemory {version} is installed.", DotMemoryCommandKind.GlobalTool);
                 }
             }
 
             return new ToolStatus(
                 true,
                 string.IsNullOrWhiteSpace(command.Version) ? null : command.Version,
-                $"{command.DisplayName} is available.");
+                $"{command.DisplayName} is available.",
+                command.Kind);
         }
 
-        // Legacy compatibility path: keep old install behavior as a fallback only.
+        // Try auto-install before legacy fallback
+        if (autoInstaller is not null)
+        {
+            var unsupportedMsg = autoInstaller.GetUnsupportedPlatformMessage();
+            if (unsupportedMsg is not null)
+                return new ToolStatus(false, null, unsupportedMsg);
+
+            var autoPath = await autoInstaller.InstallLatestAsync(ct).ConfigureAwait(false);
+            if (autoPath is not null)
+            {
+                InvalidateCache();
+                command = await ResolveCommandAsync(ct).ConfigureAwait(false);
+                if (command is not null)
+                    return new ToolStatus(true, command.Version, $"{command.DisplayName} is available.", command.Kind);
+            }
+        }
+
+        // Legacy compatibility path
         var installResult = await processRunner
             .RunAsync("dotnet", "tool install -g dotnet-dotmemory", ct)
             .ConfigureAwait(false);
@@ -76,28 +94,16 @@ public class DotMemoryToolManager(IProcessRunner processRunner)
                 "put dotMemory in PATH, or install dotnet-dotmemory.";
 
             if (!string.IsNullOrWhiteSpace(installResult.Error))
-            {
                 errorMessage += $" Details: {installResult.Error}";
-            }
 
-            return new ToolStatus(
-                false,
-                null,
-                errorMessage);
+            return new ToolStatus(false, null, errorMessage);
         }
 
         command = await ResolveCommandAsync(ct).ConfigureAwait(false);
         if (command is not null)
-        {
-            return new ToolStatus(
-                true,
-                string.IsNullOrWhiteSpace(command.Version) ? null : command.Version,
-                $"{command.DisplayName} is available.");
-        }
+            return new ToolStatus(true, command.Version, $"{command.DisplayName} is available.", command.Kind);
 
-        return new ToolStatus(
-            false,
-            null,
+        return new ToolStatus(false, null,
             "dotnet-dotmemory was installed, but the executable could not be resolved. " +
             "Add the .NET tools directory to PATH or set DOTMEMORY_PATH explicitly.");
     }
@@ -108,25 +114,16 @@ public class DotMemoryToolManager(IProcessRunner processRunner)
             return _cachedCommand;
 
         var configured = ResolveConfiguredPath();
-        if (configured is not null)
-        {
-            _cachedCommand = configured;
-            return configured;
-        }
+        if (configured is not null) { _cachedCommand = configured; return configured; }
+
+        var autoInstalled = await ResolveAutoInstalledAsync(ct).ConfigureAwait(false);
+        if (autoInstalled is not null) { _cachedCommand = autoInstalled; return autoInstalled; }
 
         var fromPath = await ResolveFromPathAsync(ct).ConfigureAwait(false);
-        if (fromPath is not null)
-        {
-            _cachedCommand = fromPath;
-            return fromPath;
-        }
+        if (fromPath is not null) { _cachedCommand = fromPath; return fromPath; }
 
         var localTool = await ResolveLocalToolAsync(ct).ConfigureAwait(false);
-        if (localTool is not null)
-        {
-            _cachedCommand = localTool;
-            return localTool;
-        }
+        if (localTool is not null) { _cachedCommand = localTool; return localTool; }
 
         var globalTool = await ResolveGlobalToolAsync(ct).ConfigureAwait(false);
         _cachedCommand = globalTool;
@@ -136,6 +133,23 @@ public class DotMemoryToolManager(IProcessRunner processRunner)
     public void InvalidateCache()
     {
         _cachedCommand = null;
+    }
+
+    private async Task<DotMemoryCommand?> ResolveAutoInstalledAsync(CancellationToken ct)
+    {
+        if (autoInstaller is null)
+            return null;
+
+        var path = await autoInstaller.GetCachedPathAsync(ct).ConfigureAwait(false);
+        if (path is null)
+            return null;
+
+        return new DotMemoryCommand(
+            path,
+            "",
+            $"auto-installed dotMemory ({path})",
+            null,
+            DotMemoryCommandKind.AutoInstalled);
     }
 
     private DotMemoryCommand? ResolveConfiguredPath()

--- a/src/MemoryLens.Mcp/Profiler/IDotMemoryAutoInstaller.cs
+++ b/src/MemoryLens.Mcp/Profiler/IDotMemoryAutoInstaller.cs
@@ -1,0 +1,15 @@
+namespace MemoryLens.Mcp.Profiler;
+
+public interface IDotMemoryAutoInstaller
+{
+    /// <summary>Returns the path to the cached dotMemory executable, or null if not cached.</summary>
+    Task<string?> GetCachedPathAsync(CancellationToken ct);
+
+    /// <summary>Downloads and caches the latest dotMemory for the current platform.
+    /// Returns the executable path on success, null on failure (network error, unsupported platform).</summary>
+    Task<string?> InstallLatestAsync(CancellationToken ct);
+
+    /// <summary>Returns a human-readable message if the current platform is not supported by
+    /// JetBrains dotMemory Console, or null if the platform is supported.</summary>
+    string? GetUnsupportedPlatformMessage();
+}

--- a/src/MemoryLens.Mcp/Program.cs
+++ b/src/MemoryLens.Mcp/Program.cs
@@ -12,6 +12,7 @@ builder.Logging.AddConsole(options =>
 });
 
 builder.Services.AddSingleton<IProcessRunner, ProcessRunner>();
+// TODO: register DotMemoryAutoInstaller in DI (Task 6)
 builder.Services.AddSingleton<DotMemoryToolManager>();
 builder.Services.AddSingleton<ProcessFilter>();
 builder.Services.AddSingleton<SnapshotManager>();

--- a/src/MemoryLens.Mcp/Program.cs
+++ b/src/MemoryLens.Mcp/Program.cs
@@ -16,7 +16,9 @@ builder.Services.AddHttpClient<DotMemoryAutoInstaller>();
 builder.Services.AddSingleton<IDotMemoryAutoInstaller>(sp =>
     new DotMemoryAutoInstaller(
         sp.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(DotMemoryAutoInstaller))));
-builder.Services.AddSingleton<DotMemoryToolManager>();
+builder.Services.AddSingleton<DotMemoryToolManager>(sp => new DotMemoryToolManager(
+    sp.GetRequiredService<IProcessRunner>(),
+    sp.GetRequiredService<IDotMemoryAutoInstaller>()));
 builder.Services.AddSingleton<ProcessFilter>();
 builder.Services.AddSingleton<SnapshotManager>();
 builder.Services.AddSingleton<MemoryLensConfig>(sp =>

--- a/src/MemoryLens.Mcp/Program.cs
+++ b/src/MemoryLens.Mcp/Program.cs
@@ -12,7 +12,10 @@ builder.Logging.AddConsole(options =>
 });
 
 builder.Services.AddSingleton<IProcessRunner, ProcessRunner>();
-// TODO: register DotMemoryAutoInstaller in DI (Task 6)
+builder.Services.AddHttpClient<DotMemoryAutoInstaller>();
+builder.Services.AddSingleton<IDotMemoryAutoInstaller>(sp =>
+    new DotMemoryAutoInstaller(
+        sp.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(DotMemoryAutoInstaller))));
 builder.Services.AddSingleton<DotMemoryToolManager>();
 builder.Services.AddSingleton<ProcessFilter>();
 builder.Services.AddSingleton<SnapshotManager>();

--- a/src/MemoryLens.Mcp/Properties/AssemblyInfo.cs
+++ b/src/MemoryLens.Mcp/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("MemoryLens.Mcp.Tests")]

--- a/tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryAutoInstallerTests.cs
+++ b/tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryAutoInstallerTests.cs
@@ -1,0 +1,91 @@
+using MemoryLens.Mcp.Profiler;
+using Xunit;
+
+namespace MemoryLens.Mcp.Tests.Profiler;
+
+public class DotMemoryAutoInstallerTests
+{
+    [Fact]
+    public void GetRid_ReturnsNonNull_OnCurrentPlatform()
+    {
+        var rid = DotMemoryAutoInstaller.GetRid();
+        Assert.NotNull(rid);
+    }
+
+    [Theory]
+    [InlineData(false, false, "linux-x64")]
+    [InlineData(false, true, "linux-musl-x64")]
+    [InlineData(true, false, "linux-arm64")]
+    [InlineData(true, true, "linux-musl-arm64")]
+    public void BuildLinuxRid_ReturnsCorrectSuffix(bool isArm64, bool isMusl, string expected)
+    {
+        Assert.Equal(expected, DotMemoryAutoInstaller.BuildLinuxRid(isArm64, isMusl));
+    }
+
+    [Fact]
+    public void GetUnsupportedPlatformMessage_ReturnsNull_OnCurrentPlatform()
+    {
+        var http = new System.Net.Http.HttpClient();
+        var installer = new DotMemoryAutoInstaller(http);
+        Assert.Null(installer.GetUnsupportedPlatformMessage());
+    }
+
+    [Fact]
+    public async Task GetCachedPath_ReturnsNull_WhenNoCacheDir()
+    {
+        var installer = new DotMemoryAutoInstaller(
+            new System.Net.Http.HttpClient(),
+            cacheRoot: Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+        var result = await installer.GetCachedPathAsync(TestContext.Current.CancellationToken);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetCachedPath_ReturnsNull_WhenCurrentTxtMissing()
+    {
+        var cacheRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(cacheRoot);
+        try
+        {
+            var installer = new DotMemoryAutoInstaller(new System.Net.Http.HttpClient(), cacheRoot);
+            var result = await installer.GetCachedPathAsync(TestContext.Current.CancellationToken);
+            Assert.Null(result);
+        }
+        finally { Directory.Delete(cacheRoot, recursive: true); }
+    }
+
+    [Fact]
+    public async Task GetCachedPath_ReturnsPath_WhenExecutableExists()
+    {
+        var cacheRoot = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var versionDir = Path.Combine(cacheRoot, "2026.1.0");
+        var toolsDir = Path.Combine(versionDir, "tools");
+        Directory.CreateDirectory(toolsDir);
+
+        var exeName = OperatingSystem.IsWindows() ? "dotMemory.exe" : "dotMemory.sh";
+        var exePath = Path.Combine(toolsDir, exeName);
+        File.WriteAllText(exePath, "fake");
+        await File.WriteAllTextAsync(Path.Combine(cacheRoot, "current.txt"), "2026.1.0");
+
+        try
+        {
+            var installer = new DotMemoryAutoInstaller(new System.Net.Http.HttpClient(), cacheRoot);
+            var result = await installer.GetCachedPathAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(exePath, result);
+        }
+        finally { Directory.Delete(cacheRoot, recursive: true); }
+    }
+
+    [Fact]
+    public async Task FetchLatestVersion_ReturnsLastVersion_FromJson()
+    {
+        var json = """{"versions":["2025.3.0","2026.1.0"]}""";
+        var http = new HttpClient(new FakeHttpMessageHandler(json));
+        var installer = new DotMemoryAutoInstaller(http, Path.GetTempPath());
+
+        var version = await installer.FetchLatestVersionAsync(
+            "jetbrains.dotmemory.console.windows-x64", TestContext.Current.CancellationToken);
+
+        Assert.Equal("2026.1.0", version);
+    }
+}

--- a/tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryToolManagerTests.cs
+++ b/tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryToolManagerTests.cs
@@ -119,4 +119,66 @@ public class DotMemoryToolManagerTests
         Assert.True(result.IsInstalled);
         Assert.Contains("Explicit Path CLI", result.Message);
     }
+
+    [Fact]
+    public async Task ResolveCommand_ReturnsAutoInstalled_WhenCacheHit()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var autoInstaller = new FakeDotMemoryAutoInstaller(cachedPath: tempFile);
+            var manager = new DotMemoryToolManager(new FakeProcessRunner(exitCode: 1, output: ""), autoInstaller);
+
+            var command = await manager.ResolveCommandAsync(TestContext.Current.CancellationToken);
+
+            Assert.NotNull(command);
+            Assert.Equal(tempFile, command.FileName);
+            Assert.Equal(DotMemoryCommandKind.AutoInstalled, command.Kind);
+        }
+        finally { File.Delete(tempFile); }
+    }
+
+    [Fact]
+    public async Task EnsureInstalled_CallsInstallLatest_WhenCacheMiss()
+    {
+        var tempFile = Path.GetTempFileName();
+        try
+        {
+            var autoInstaller = new FakeDotMemoryAutoInstaller(cachedPath: null, installPath: tempFile);
+            var manager = new DotMemoryToolManager(new FakeProcessRunner(exitCode: 1, output: ""), autoInstaller);
+
+            var result = await manager.EnsureInstalledAsync(TestContext.Current.CancellationToken);
+
+            Assert.True(result.IsInstalled);
+            Assert.Equal(DotMemoryCommandKind.AutoInstalled, result.Kind);
+        }
+        finally { File.Delete(tempFile); }
+    }
+
+    [Fact]
+    public async Task EnsureInstalled_FallsThrough_WhenInstallLatestFails()
+    {
+        var autoInstaller = new FakeDotMemoryAutoInstaller(cachedPath: null, installPath: null);
+        var runner = new FakeProcessRunner(exitCode: 1, output: "");
+        var manager = new DotMemoryToolManager(runner, autoInstaller);
+
+        var result = await manager.EnsureInstalledAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsInstalled);
+    }
+
+    [Fact]
+    public async Task EnsureInstalled_ReturnsUnsupportedMessage_WhenPlatformNotSupported()
+    {
+        var autoInstaller = new FakeDotMemoryAutoInstaller(
+            unsupportedMessage: "Platform freebsd-x64 is not supported.");
+        var runner = new FakeProcessRunner(exitCode: 1, output: "");
+        var manager = new DotMemoryToolManager(runner, autoInstaller);
+
+        var result = await manager.EnsureInstalledAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsInstalled);
+        Assert.Contains("freebsd-x64", result.Message);
+        Assert.Equal(0, autoInstaller.InstallLatestAsyncCallCount);
+    }
 }

--- a/tests/MemoryLens.Mcp.Tests/Profiler/FakeDotMemoryAutoInstaller.cs
+++ b/tests/MemoryLens.Mcp.Tests/Profiler/FakeDotMemoryAutoInstaller.cs
@@ -7,11 +7,24 @@ public class FakeDotMemoryAutoInstaller(
     string? installPath = null,
     string? unsupportedMessage = null) : IDotMemoryAutoInstaller
 {
-    public Task<string?> GetCachedPathAsync(CancellationToken ct) =>
-        Task.FromResult(cachedPath);
+    private bool _installed;
 
-    public Task<string?> InstallLatestAsync(CancellationToken ct) =>
-        Task.FromResult(installPath);
+    public int InstallLatestAsyncCallCount { get; private set; }
+
+    public Task<string?> GetCachedPathAsync(CancellationToken ct)
+    {
+        // After InstallLatestAsync has been called successfully, return the installPath as cached.
+        var result = _installed ? installPath : cachedPath;
+        return Task.FromResult(result);
+    }
+
+    public Task<string?> InstallLatestAsync(CancellationToken ct)
+    {
+        InstallLatestAsyncCallCount++;
+        if (installPath is not null)
+            _installed = true;
+        return Task.FromResult(installPath);
+    }
 
     public string? GetUnsupportedPlatformMessage() => unsupportedMessage;
 }

--- a/tests/MemoryLens.Mcp.Tests/Profiler/FakeDotMemoryAutoInstaller.cs
+++ b/tests/MemoryLens.Mcp.Tests/Profiler/FakeDotMemoryAutoInstaller.cs
@@ -1,0 +1,17 @@
+using MemoryLens.Mcp.Profiler;
+
+namespace MemoryLens.Mcp.Tests.Profiler;
+
+public class FakeDotMemoryAutoInstaller(
+    string? cachedPath = null,
+    string? installPath = null,
+    string? unsupportedMessage = null) : IDotMemoryAutoInstaller
+{
+    public Task<string?> GetCachedPathAsync(CancellationToken ct) =>
+        Task.FromResult(cachedPath);
+
+    public Task<string?> InstallLatestAsync(CancellationToken ct) =>
+        Task.FromResult(installPath);
+
+    public string? GetUnsupportedPlatformMessage() => unsupportedMessage;
+}

--- a/tests/MemoryLens.Mcp.Tests/Profiler/FakeHttpMessageHandler.cs
+++ b/tests/MemoryLens.Mcp.Tests/Profiler/FakeHttpMessageHandler.cs
@@ -1,0 +1,13 @@
+using System.Net;
+
+namespace MemoryLens.Mcp.Tests.Profiler;
+
+public class FakeHttpMessageHandler(string responseBody, HttpStatusCode statusCode = HttpStatusCode.OK)
+    : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
+        Task.FromResult(new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(responseBody, System.Text.Encoding.UTF8, "application/json")
+        });
+}

--- a/tests/MemoryLens.Mcp.Tests/Profiler/FakeProcessRunner.cs
+++ b/tests/MemoryLens.Mcp.Tests/Profiler/FakeProcessRunner.cs
@@ -5,10 +5,12 @@ namespace MemoryLens.Mcp.Tests.Profiler;
 public class FakeProcessRunner : IProcessRunner
 {
     private readonly Queue<ProcessResult> _results = new();
+    private readonly ProcessResult _defaultResult;
 
     public FakeProcessRunner(int exitCode, string output)
     {
-        _results.Enqueue(new ProcessResult(exitCode, output, ""));
+        _defaultResult = new ProcessResult(exitCode, output, "");
+        _results.Enqueue(_defaultResult);
     }
 
     public void SetNextResult(int exitCode, string output)
@@ -21,7 +23,7 @@ public class FakeProcessRunner : IProcessRunner
     {
         var result = _results.Count > 0
             ? _results.Dequeue()
-            : new ProcessResult(0, "", "");
+            : _defaultResult;
         return Task.FromResult(result);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `DotMemoryAutoInstaller` that downloads the official `JetBrains.dotMemory.Console.*` NuGet redistributable package on first use, so users don't need to manually install anything
- Supports all 10 JetBrains-published platforms: Windows (x64/x86/arm64), Linux glibc (x64/arm64/arm), Linux musl (x64/arm64), macOS (x64/arm64)
- Binaries are cached in `~/.memorylens/tools/dotmemory/{version}/` — subsequent runs use the cache with no network call
- Falls back gracefully to `DOTMEMORY_PATH` / PATH discovery on unsupported platforms or network failure
- `IDotMemoryAutoInstaller` interface keeps HTTP/filesystem code out of unit tests; CI tests pass with a fake

## What changed

- `src/MemoryLens.Mcp/Profiler/IDotMemoryAutoInstaller.cs` — interface
- `src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs` — implementation (NuGet download, extraction, chmod, cache)
- `src/MemoryLens.Mcp/Profiler/DotMemoryToolManager.cs` — new `AutoInstalled` discovery step; `EnsureInstalledAsync` triggers download on cache miss
- `src/MemoryLens.Mcp/Program.cs` — DI wiring for `DotMemoryAutoInstaller` + `IHttpClientFactory`
- `src/MemoryLens.Mcp/MemoryLens.Mcp.csproj` — added `Microsoft.Extensions.Http`
- `tests/` — `FakeDotMemoryAutoInstaller`, `DotMemoryAutoInstallerTests`, `FakeHttpMessageHandler`, 4 new `DotMemoryToolManagerTests`
- `README.md` — updated installation docs with supported platforms table, cache location, error scenarios

## Test plan

- [ ] CI passes all 106 unit tests
- [ ] On a machine without dotMemory: `ensure_dotmemory` downloads and caches the binary
- [ ] Second call uses cache (no network)
- [ ] `DOTMEMORY_PATH` still takes priority when set

🤖 Generated with [Claude Code](https://claude.com/claude-code)