### PR TITLE
fix: fall back to --help for dotMemory CLI version probe

### DIFF
--- a/src/MemoryLens.Mcp/Profiler/DotMemoryToolManager.cs
+++ b/src/MemoryLens.Mcp/Profiler/DotMemoryToolManager.cs
@@ -181,12 +181,26 @@ public class DotMemoryToolManager(IProcessRunner processRunner, IDotMemoryAutoIn
 
     private string? TryProbeSync(string fileName)
     {
+        var firstLine = RunSync(fileName, "--version");
+        if (firstLine is not null)
+            return firstLine;
+
+        // The new JetBrains dotMemory CLI does not support --version; try --help instead.
+        var helpFirstLine = RunSync(fileName, "--help");
+        if (helpFirstLine is not null && helpFirstLine.Contains("dotMemory", StringComparison.OrdinalIgnoreCase))
+            return helpFirstLine;
+
+        return null;
+    }
+
+    private static string? RunSync(string fileName, string arguments)
+    {
         try
         {
             var startInfo = new System.Diagnostics.ProcessStartInfo
             {
                 FileName = fileName,
-                Arguments = "--version",
+                Arguments = arguments,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
@@ -206,11 +220,9 @@ public class DotMemoryToolManager(IProcessRunner processRunner, IDotMemoryAutoIn
             var error = process.StandardError.ReadToEnd();
             var text = string.IsNullOrWhiteSpace(output) ? error : output;
 
-            var firstLine = text
+            return text
                 .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                .FirstOrDefault();
-
-            return firstLine ?? string.Empty;
+                .FirstOrDefault() ?? string.Empty;
         }
         catch
         {
@@ -308,20 +320,31 @@ public class DotMemoryToolManager(IProcessRunner processRunner, IDotMemoryAutoIn
         if (result is null)
             return null;
 
-        // Require successful exit code to validate this is actually dotMemory
-        if (result.ExitCode != 0)
+        if (result.ExitCode == 0)
+        {
+            var text = string.IsNullOrWhiteSpace(result.Output) ? result.Error : result.Output;
+            var firstLine = text
+                .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault();
+            return firstLine ?? string.Empty;
+        }
+
+        // The new JetBrains dotMemory CLI (dotMemory.exe / dotMemory.sh) does not support
+        // --version and exits non-zero. Fall back to --help, which prints the version on the
+        // first line: "dotMemory Console Profiler 2026.1.0.1 build ..."
+        var helpResult = await TryRunAsync(fileName, "--help", ct).ConfigureAwait(false);
+        if (helpResult is null)
             return null;
 
-        var text = string.IsNullOrWhiteSpace(result.Output)
-            ? result.Error
-            : result.Output;
-
-        var firstLine = text
+        var helpText = string.IsNullOrWhiteSpace(helpResult.Output) ? helpResult.Error : helpResult.Output;
+        var helpFirstLine = helpText
             .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .FirstOrDefault();
+            .FirstOrDefault() ?? string.Empty;
 
-        // Non-null means "process started", even if it doesn't print version.
-        return firstLine ?? string.Empty;
+        // Only accept if the output identifies this as a dotMemory binary.
+        return helpFirstLine.Contains("dotMemory", StringComparison.OrdinalIgnoreCase)
+            ? helpFirstLine
+            : null;
     }
 
     private async Task<ProcessResult?> TryRunAsync(string fileName, string arguments, CancellationToken ct)

--- a/tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryToolManagerTests.cs
+++ b/tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryToolManagerTests.cs
@@ -181,4 +181,22 @@ public class DotMemoryToolManagerTests
         Assert.Contains("freebsd-x64", result.Message);
         Assert.Equal(0, autoInstaller.InstallLatestAsyncCallCount);
     }
+
+    [Fact]
+    public async Task ResolveCommand_UsesHelpFallback_WhenVersionCommandFails()
+    {
+        // Arrange: --version exits non-zero (new JetBrains CLI), --help succeeds
+        const string helpOutput =
+            "dotMemory Console Profiler 2026.1.0.1 build 261.0.20260408.225500. Copyright (C) 2017-2026 JetBrains s.r.o.";
+        var runner = new FakeProcessRunner(exitCode: 1, output: "");  // --version fails
+        runner.SetNextResult(exitCode: 0, output: helpOutput);          // --help succeeds
+
+        var manager = new DotMemoryToolManager(runner);
+
+        var command = await manager.ResolveCommandAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(command);
+        Assert.Equal(DotMemoryCommandKind.PathDiscovery, command.Kind);
+        Assert.Contains("dotMemory", command.Version, StringComparison.OrdinalIgnoreCase);
+    }
 }


### PR DESCRIPTION
Fixes #44

## Summary

- The new JetBrains dotMemory CLI (`dotMemory.exe` / `dotMemory.sh`) rejects `--version` with `Unrecognized option 'version': '--version'` and exits non-zero, causing PATH discovery to silently skip the binary
- Both `TryProbeAsync` (PATH discovery) and `TryProbeSync` (`DOTMEMORY_PATH` version extraction) now fall back to `--help` when `--version` exits non-zero
- The first line of `--help` output (`dotMemory Console Profiler 2026.1.0.1 build...`) is only accepted if it contains `"dotMemory"` — avoids false positives on unrelated binaries

## Test plan

- [ ] CI passes all tests
- [ ] `ResolveCommand_UsesHelpFallback_WhenVersionCommandFails` covers the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)