### PR TITLE
feat: Docker support and glama.json for Glama indexing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Everything the image does not need. Keeping bin/ and obj/ out matters most:
+# host build output leaking into the build context breaks the container restore.
+**/bin/
+**/obj/
+.git/
+.github/
+.vs/
+.vscode/
+.claude/
+TestResults/
+artifacts/
+
+tests/
+docs/
+skills/
+npm/
+samples/
+
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1
+#
+# MemoryLens MCP server.
+#
+# Wraps JetBrains dotMemory Console, which supports linux-x64 / linux-arm64
+# (see DotMemoryAutoInstaller.GetRid), so profiling from a container works — but
+# attaching a profiler to a process needs ptrace, and seeing processes outside
+# the container needs the host PID namespace:
+#
+#   docker build -t memorylens-mcp .
+#   docker run -i --rm --pid=host --cap-add=SYS_PTRACE \
+#     -v "$PWD:/workspace" -v memorylens-tools:/root/.memorylens \
+#     memorylens-mcp
+#
+# See docs/docker.md for MCP client configuration and the caveats.
+
+# ---------------------------------------------------------------- build -------
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+
+WORKDIR /src
+
+# Restore against the project file alone so the (slow) restore layer survives
+# source-only edits. Directory.Build.props carries the shared analyzer set.
+COPY Directory.Build.props ./
+COPY src/MemoryLens.Mcp/MemoryLens.Mcp.csproj src/MemoryLens.Mcp/
+RUN dotnet restore src/MemoryLens.Mcp/MemoryLens.Mcp.csproj
+
+COPY src/ src/
+RUN dotnet publish src/MemoryLens.Mcp/MemoryLens.Mcp.csproj \
+      --configuration Release \
+      --no-restore \
+      --output /app
+
+# -------------------------------------------------------------- runtime -------
+# Must be the SDK image, not dotnet/runtime: DotMemoryToolManager falls back to
+# `dotnet tool install -g dotnet-dotmemory`, which requires the SDK. dotMemory
+# Console is glibc-linked, so this is also why the image is not Alpine-based.
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+
+ENV DOTNET_NOLOGO=1 \
+    DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 \
+    PATH="/root/.dotnet/tools:${PATH}"
+
+# The profiler is NOT baked in: ensure_dotmemory downloads the
+# JetBrains.dotMemory.Console.<rid> nupkg from nuget.org at runtime and extracts
+# it under $HOME/.memorylens. Mount a volume there (see docs/docker.md) so the
+# download survives --rm; a cold container needs network access for it.
+COPY --from=build /app /opt/memorylens
+
+# .memorylens.json is read from the working directory (see Program.cs), and
+# snapshots land here — mount your project so both survive the container.
+WORKDIR /workspace
+
+ENTRYPOINT ["dotnet", "/opt/memorylens/MemoryLens.Mcp.dll"]

--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ claude install gh:MarcelRoozekrans/memorylens-mcp
 dotnet tool install -g MemoryLens.Mcp
 ```
 
+### Docker
+
+```bash
+docker build -t memorylens-mcp .
+docker run -i --rm --pid=host --cap-add=SYS_PTRACE \
+  -v "$PWD:/workspace" -v memorylens-tools:/root/.memorylens memorylens-mcp
+```
+
+Profiling from a container needs `ptrace` and the host PID namespace, and on
+Docker Desktop that namespace is the Linux VM rather than your desktop — see
+[docs/docker.md](docs/docker.md) before choosing this route.
+
 ## Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) or later

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,92 @@
+# Running in Docker
+
+The repository ships a `Dockerfile`, so you can run the server without a .NET SDK
+on the host. Read the [limitations](#limitations) first — profiling from a
+container is more constrained than the other install methods.
+
+## Build the image
+
+```bash
+docker build -t memorylens-mcp .
+```
+
+## Run it
+
+The server communicates over stdio, so the container needs `-i` and must not
+allocate a TTY:
+
+```bash
+docker run -i --rm --pid=host --cap-add=SYS_PTRACE \
+  -v "$PWD:/workspace" \
+  -v memorylens-tools:/root/.memorylens \
+  memorylens-mcp
+```
+
+| Flag | Why |
+|---|---|
+| `--pid=host` | Without it `list_processes` sees only the container's own PIDs, so there is nothing to profile. |
+| `--cap-add=SYS_PTRACE` | dotMemory attaches to a running process; that needs `ptrace`, which Docker drops by default. |
+| `-v memorylens-tools:/root/.memorylens` | Persists the dotMemory CLI that `ensure_dotmemory` downloads (~hundreds of MB) so it is fetched once, not per container start. |
+| `-v "$PWD:/workspace"` | `.memorylens.json` is read from the working directory, and snapshots are written there. |
+
+## MCP client configuration
+
+```json
+{
+  "mcpServers": {
+    "memorylens": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "--pid=host", "--cap-add=SYS_PTRACE",
+        "-v", "/absolute/path/to/your/repo:/workspace",
+        "-v", "memorylens-tools:/root/.memorylens",
+        "memorylens-mcp"
+      ]
+    }
+  }
+}
+```
+
+## Call `ensure_dotmemory` first
+
+The profiler is not baked into the image. `ensure_dotmemory` downloads the
+`JetBrains.dotMemory.Console.<rid>` package from nuget.org on first use and
+extracts it under `$HOME/.memorylens` — so a cold container needs network
+access, and the `/root/.memorylens` volume is what stops it re-downloading on
+every start.
+
+Calling `list_processes` before `ensure_dotmemory` fails with *"Could not execute
+because the specified command or file was not found"*: it shells out to
+`dotnet dotmemory list-processes`, which needs a `dotnet-dotmemory` command on
+`PATH`. This is not container-specific — it behaves the same way on a host
+without that tool.
+
+The image is SDK-based rather than `dotnet/runtime` because `DotMemoryToolManager`
+falls back to `dotnet tool install`, which requires the SDK.
+
+## Windows hosts
+
+Under Git Bash / MSYS, path arguments are rewritten before Docker sees them —
+`/workspace` becomes `C:/Program Files/Git/workspace`. Prefix the command with
+`MSYS_NO_PATHCONV=1`, or use PowerShell:
+
+```powershell
+docker run -i --rm -v "${PWD}:/workspace" memorylens-mcp
+```
+
+## Limitations
+
+- **The target process must be reachable.** A containerized profiler can only
+  attach to processes in a PID namespace it shares. `--pid=host` covers processes
+  on the Docker host; profiling a process in a *different* container additionally
+  needs `--pid=container:<id>`.
+- **Docker Desktop hosts are a VM.** On Windows and macOS `--pid=host` is the
+  Linux VM's namespace, not your desktop's, so a .NET app running natively on
+  Windows or macOS is not visible. Use the [global tool](../README.md#net-global-tool)
+  or [npx](../README.md#npx-any-mcp-client) install for those.
+- **Linux glibc/musl only.** dotMemory Console has no container-friendly build
+  for other platforms; set `DOTMEMORY_PATH` if you supply your own.
+- **Snapshots are container paths.** They land under `/workspace`, so mount a
+  volume there or they vanish with `--rm`.

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["MarcelRoozekrans"]
+}


### PR DESCRIPTION
Companion to MarcelRoozekrans/roslyn-codelens-mcp#348 — same two changes, applied to this server.

## What this addresses

Glama's score flags a missing `glama.json`, and gates both **Server Coherence** and **Tool Definition Quality** behind having a published release, which Glama builds from a Dockerfile. This PR adds both.

`glama.json` is tiny because [the schema](https://glama.ai/mcp/schemas/server.json) requires exactly one field, `maintainers`.

## Containerized profiling is constrained — the docs lead with that

Unlike roslyn-codelens, running this server in Docker is genuinely more limited than the other install methods, so `docs/docker.md` says so up front:

- dotMemory attaches to a target via `ptrace` → needs `--cap-add=SYS_PTRACE`.
- It only sees processes in a PID namespace it shares → needs `--pid=host`.
- **On Docker Desktop that namespace is the Linux VM, not your desktop**, so a natively-running Windows or macOS app is not visible at all. The global tool or npx install remains the right choice there.

## Why the profiler is not baked into the image

I tried `RUN dotnet tool install -g dotnet-dotmemory` and the build failed: **that package does not exist on nuget.org.** JetBrains ships `JetBrains.dotMemory.Console.<rid>` as plain dependency packages, which is what `DotMemoryAutoInstaller` downloads and extracts directly. So `ensure_dotmemory` is the only working path, and a volume at `$HOME/.memorylens` is what keeps the payload across `--rm`.

The runtime stage still uses `dotnet/sdk` rather than `dotnet/runtime`, because `DotMemoryToolManager` falls back to `dotnet tool install`, which needs the SDK.

## Verification

Built and ran the image:

- `tools/list` returns all **6 tools**; logs correctly go to stderr, stdout is pure JSON-RPC.
- `ensure_dotmemory` works inside the container — downloaded and extracted dotMemory 2026.2.0 to `/root/.memorylens/tools/dotmemory/2026.2.0/tools/dotMemory.sh`.

## Pre-existing bug found while testing (not fixed here)

**`list_processes` fails on every platform, not just in Docker.** `ListProcessesTool.cs:20-21` hardcodes `dotnet dotmemory list-processes` instead of resolving through `DotMemoryToolManager`. It fails *after* `ensure_dotmemory` succeeds, because extracting a nupkg under `~/.memorylens` does not register a `dotnet-dotmemory` command:

```
Failed to list processes: Could not execute because the specified command or file was not found.
```

Confirmed on a Windows host too, with `memorylens.mcp 1.5.2` installed globally — `dotnet dotmemory` does not resolve there either. Left for a separate PR since the fix is a choice about which resolution path wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)