### PR TITLE
fix: make list_processes work, and restore execute bits on the extracted profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ If auto-download is unavailable, MemoryLens MCP falls back through these discove
 | Tool | Description |
 |------|-------------|
 | `ensure_dotmemory` | Downloads and verifies the JetBrains dotMemory CLI tool is available |
-| `list_processes` | Lists running .NET processes available for profiling |
+| `list_processes` | Lists running .NET processes available for profiling. Discovers them from their diagnostic IPC endpoints, so it works before `ensure_dotmemory` |
 | `snapshot` | Captures a single memory snapshot of a target process |
 | `compare_snapshots` | Captures two snapshots with configurable delay and compares them |
 | `analyze` | Runs the rule engine against a captured snapshot and returns findings |

--- a/skills/memorylens/SKILL.md
+++ b/skills/memorylens/SKILL.md
@@ -30,7 +30,8 @@ Call `ensure_dotmemory`. If it fails, stop and report the error.
 ### Step 2: Identify target
 
 Ask the user what to profile:
-- **Running process**: Call `list_processes` and let user pick
+- **Running process**: Call `list_processes` and let user pick. It needs no profiler,
+  so it is also safe to call before step 1 to check there is a target at all
 - **Launch command**: User provides a `dotnet run` command or similar
 - **Both**: Attach to running OR launch — user's choice
 

--- a/src/MemoryLens.Mcp/Profiler/DiagnosticPortProcessLister.cs
+++ b/src/MemoryLens.Mcp/Profiler/DiagnosticPortProcessLister.cs
@@ -1,0 +1,170 @@
+#pragma warning disable MA0048 // File name must match type name - intentional companion types
+using System.Diagnostics;
+using System.Globalization;
+
+namespace MemoryLens.Mcp.Profiler;
+
+public record DotNetProcess(int Pid, string Name, string CommandLine);
+
+public interface IDotNetProcessLister
+{
+    IReadOnlyList<DotNetProcess> ListProcesses();
+}
+
+/// <summary>
+/// Enumerates running .NET processes from their diagnostic IPC endpoints.
+/// <para>
+/// Every .NET Core 3.0+ runtime opens a diagnostic server by default and advertises
+/// it as a Unix domain socket under the temp directory, or as a named pipe on
+/// Windows. Both encode the owning pid, so listing the endpoints lists the
+/// profileable processes. This is the same discovery mechanism the dotnet-* CLI
+/// diagnostic tools use.
+/// </para>
+/// <para>
+/// The alternative — asking the profiler — is not available: dotMemory Console
+/// exposes only get-snapshot, attach, start, start-net-core and recover. It has no
+/// process-listing command, so this must not depend on dotMemory being installed.
+/// </para>
+/// </summary>
+public class DiagnosticPortProcessLister : IDotNetProcessLister
+{
+    private const string UnixSocketPrefix = "dotnet-diagnostic-";
+    private const string UnixSocketSuffix = "-socket";
+    private const string WindowsPipePrefix = "dotnet-diagnostic-";
+
+    private readonly string _unixEndpointDirectory;
+
+    public DiagnosticPortProcessLister(string? unixEndpointDirectory = null)
+    {
+        // The runtime honours TMPDIR when placing the socket, which is exactly what
+        // Path.GetTempPath() reads, so the default agrees with the runtime.
+        _unixEndpointDirectory = unixEndpointDirectory ?? Path.GetTempPath();
+    }
+
+    public IReadOnlyList<DotNetProcess> ListProcesses()
+    {
+        var processes = new List<DotNetProcess>();
+
+        foreach (var pid in EnumerateCandidatePids().Distinct())
+        {
+            if (Describe(pid) is { } process)
+                processes.Add(process);
+        }
+
+        return processes;
+    }
+
+    private IEnumerable<int> EnumerateCandidatePids() =>
+        OperatingSystem.IsWindows()
+            ? EnumerateWindowsPipePids()
+            : EnumerateUnixSocketPids();
+
+    private IEnumerable<int> EnumerateUnixSocketPids()
+    {
+        IEnumerable<string> entries;
+        try
+        {
+            entries = Directory.EnumerateFiles(
+                _unixEndpointDirectory, UnixSocketPrefix + "*" + UnixSocketSuffix);
+        }
+        catch (DirectoryNotFoundException) { yield break; }
+        catch (UnauthorizedAccessException) { yield break; }
+
+        foreach (var entry in entries)
+        {
+            if (TryParseUnixSocketPid(Path.GetFileName(entry), out var pid))
+                yield return pid;
+        }
+    }
+
+    private static IEnumerable<int> EnumerateWindowsPipePids()
+    {
+        IEnumerable<string> entries;
+        try
+        {
+            // The pipe filesystem does not support globbing, so filter after listing.
+            entries = Directory.GetFiles(@"\\.\pipe\");
+        }
+        catch (IOException) { return []; }
+        catch (UnauthorizedAccessException) { return []; }
+
+        var pids = new List<int>();
+        foreach (var entry in entries)
+        {
+            if (TryParseWindowsPipePid(Path.GetFileName(entry), out var pid))
+                pids.Add(pid);
+        }
+
+        return pids;
+    }
+
+    /// <summary>
+    /// Parses the pid out of "dotnet-diagnostic-{pid}-{disambiguator}-socket".
+    /// </summary>
+    internal static bool TryParseUnixSocketPid(string fileName, out int pid)
+    {
+        pid = 0;
+
+        if (!fileName.StartsWith(UnixSocketPrefix, StringComparison.Ordinal) ||
+            !fileName.EndsWith(UnixSocketSuffix, StringComparison.Ordinal))
+            return false;
+
+        var middle = fileName[UnixSocketPrefix.Length..^UnixSocketSuffix.Length];
+
+        // The disambiguator is a start-time token; the pid is everything before it.
+        var separator = middle.IndexOf('-', StringComparison.Ordinal);
+        var pidText = separator >= 0 ? middle[..separator] : middle;
+
+        return int.TryParse(pidText, NumberStyles.None, CultureInfo.InvariantCulture, out pid)
+               && pid > 0;
+    }
+
+    /// <summary>
+    /// Parses the pid out of "dotnet-diagnostic-{pid}", the Windows pipe form. Unlike
+    /// the socket name it carries no disambiguator.
+    /// </summary>
+    internal static bool TryParseWindowsPipePid(string pipeName, out int pid)
+    {
+        pid = 0;
+
+        if (!pipeName.StartsWith(WindowsPipePrefix, StringComparison.Ordinal))
+            return false;
+
+        var pidText = pipeName[WindowsPipePrefix.Length..];
+
+        return int.TryParse(pidText, NumberStyles.None, CultureInfo.InvariantCulture, out pid)
+               && pid > 0;
+    }
+
+    private static DotNetProcess? Describe(int pid)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(pid);
+            return new DotNetProcess(pid, process.ProcessName, SafeMainModulePath(process));
+        }
+        catch (ArgumentException)
+        {
+            // Stale endpoint: the process exited without cleaning its socket up.
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private static string SafeMainModulePath(Process process)
+    {
+        try
+        {
+            return process.MainModule?.FileName ?? "";
+        }
+        catch (Exception e) when (e is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            // Reading another user's module list is commonly denied; the name alone is
+            // still enough for ProcessFilter to make an exclusion decision.
+            return "";
+        }
+    }
+}

--- a/src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
+++ b/src/MemoryLens.Mcp/Profiler/DotMemoryAutoInstaller.cs
@@ -77,7 +77,18 @@ public class DotMemoryAutoInstaller(HttpClient httpClient, string? cacheRoot = n
         var version = (await File.ReadAllTextAsync(currentFile, ct).ConfigureAwait(false)).Trim();
         var versionDir = Path.Combine(_cacheRoot, version);
         var exePath = FindExecutable(versionDir);
-        return exePath is not null && File.Exists(exePath) ? exePath : null;
+        if (exePath is null || !File.Exists(exePath))
+            return null;
+
+        // Re-apply the execute bits on a cache hit as well. A cache extracted before
+        // MakeToolsExecutable walked the whole tree has an executable entry point but
+        // a non-executable runtime-dotnet.sh, and resolution would otherwise hand back
+        // a path that fails with "Permission denied" forever.
+        try { MakeToolsExecutable(versionDir); }
+        catch (IOException) { /* best effort — a read-only cache still resolves */ }
+        catch (UnauthorizedAccessException) { /* ditto */ }
+
+        return exePath;
     }
 
     private static string? FindExecutable(string versionDir)
@@ -147,7 +158,7 @@ public class DotMemoryAutoInstaller(HttpClient httpClient, string? cacheRoot = n
             return null;
         }
 
-        try { await MakeExecutableAsync(exePath).ConfigureAwait(false); }
+        try { MakeToolsExecutable(versionDir); }
         catch (OperationCanceledException) { throw; }
         catch
         {
@@ -206,16 +217,74 @@ public class DotMemoryAutoInstaller(HttpClient httpClient, string? cacheRoot = n
         }
     }
 
-    private static Task MakeExecutableAsync(string path)
+    /// <summary>
+    /// Restores the execute bit across the extracted package.
+    /// <para>
+    /// ZipFile.ExtractToDirectory discards Unix permission bits, so everything in a
+    /// .nupkg arrives as 0644. Chmodding only the entry point is not enough: the
+    /// dotMemory launcher execs runtime-dotnet.sh, which in turn execs a native host,
+    /// and the failure surfaces as "Permission denied" on that second hop.
+    /// </para>
+    /// </summary>
+    internal static void MakeToolsExecutable(string versionDir)
     {
         if (OperatingSystem.IsWindows())
-            return Task.CompletedTask;
+            return;
 
-        File.SetUnixFileMode(path,
-            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
-            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
-            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        foreach (var path in Directory.EnumerateFiles(versionDir, "*", SearchOption.AllDirectories))
+        {
+            // Cheap first: skip anything already executable so the cache-hit path does
+            // not re-stat and re-chmod the whole package on every resolve.
+            if (File.GetUnixFileMode(path).HasFlag(UnixFileMode.UserExecute))
+                continue;
 
-        return Task.CompletedTask;
+            if (!NeedsExecuteBit(path))
+                continue;
+
+            File.SetUnixFileMode(path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        }
+    }
+
+    /// <summary>
+    /// Whether a file is something the OS must be able to exec, decided by its leading
+    /// bytes rather than its name.
+    /// <para>
+    /// Naming is not a usable signal here: JetBrains ships native helpers with
+    /// dotted names (JetBrains.Profiler.PdbServer), so Path.GetExtension reports
+    /// ".PdbServer" and an "extensionless means native" rule silently misses them.
+    /// Managed assemblies start with "MZ" and are launched through the host, so they
+    /// are excluded for free.
+    /// </para>
+    /// </summary>
+    internal static bool NeedsExecuteBit(string path)
+    {
+        Span<byte> header = stackalloc byte[4];
+
+        int read;
+        try
+        {
+            using var stream = File.OpenRead(path);
+            read = stream.ReadAtLeast(header, header.Length, throwOnEndOfStream: false);
+        }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+
+        // Shebang: "#!"
+        if (read >= 2 && header[0] == 0x23 && header[1] == 0x21)
+            return true;
+
+        if (read < 4)
+            return false;
+
+        // ELF: 0x7F 'E' 'L' 'F'
+        if (header[0] == 0x7F && header[1] == 0x45 && header[2] == 0x4C && header[3] == 0x46)
+            return true;
+
+        // Mach-O, 32/64-bit either endianness, plus universal binaries.
+        var magic = (uint)(header[0] << 24 | header[1] << 16 | header[2] << 8 | header[3]);
+        return magic is 0xFEEDFACE or 0xFEEDFACF or 0xCEFAEDFE or 0xCFFAEDFE or 0xCAFEBABE;
     }
 }

--- a/src/MemoryLens.Mcp/Program.cs
+++ b/src/MemoryLens.Mcp/Program.cs
@@ -20,6 +20,7 @@ builder.Services.AddSingleton<DotMemoryToolManager>(sp => new DotMemoryToolManag
     sp.GetRequiredService<IProcessRunner>(),
     sp.GetRequiredService<IDotMemoryAutoInstaller>()));
 builder.Services.AddSingleton<ProcessFilter>();
+builder.Services.AddSingleton<IDotNetProcessLister>(_ => new DiagnosticPortProcessLister());
 builder.Services.AddSingleton<SnapshotManager>();
 builder.Services.AddSingleton<MemoryLensConfig>(sp =>
     ConfigLoader.LoadFromPath(Path.Combine(Directory.GetCurrentDirectory(), ".memorylens.json")));

--- a/src/MemoryLens.Mcp/Tools/ListProcessesTool.cs
+++ b/src/MemoryLens.Mcp/Tools/ListProcessesTool.cs
@@ -1,6 +1,4 @@
-#pragma warning disable MA0048 // File name must match type name - intentional companion types
 using System.ComponentModel;
-using System.Globalization;
 using System.Text.Json;
 using MemoryLens.Mcp.Profiler;
 using ModelContextProtocol.Server;
@@ -8,43 +6,31 @@ using ModelContextProtocol.Server;
 namespace MemoryLens.Mcp.Tools;
 
 [McpServerToolType]
-public class ListProcessesTool(IProcessRunner processRunner, ProcessFilter processFilter)
+public class ListProcessesTool(IDotNetProcessLister processLister, ProcessFilter processFilter)
 {
     [McpServerTool, Description(
-        "Lists running .NET processes suitable for memory profiling. " +
+        "Lists running .NET processes suitable for memory profiling, discovered from " +
+        "their diagnostic IPC endpoints. Does not require dotMemory to be installed. " +
         "Excludes IDE, tooling, and MCP server processes to prevent interference.")]
-    public async Task<string> list_processes(
+    public Task<string> list_processes(
         [Description("Optional filter to match process name")] string? filter = null,
         CancellationToken ct = default)
     {
-        var result = await processRunner.RunAsync(
-            "dotnet", "dotmemory list-processes", ct).ConfigureAwait(false);
+        ct.ThrowIfCancellationRequested();
 
-        if (result.ExitCode != 0)
-            return $"Failed to list processes: {result.Error}";
-
-        var processes = ParseProcessList(result.Output)
+        var processes = processLister.ListProcesses()
+            // Exclude ourselves by pid, not by name. ProcessFilter matches "MemoryLens.Mcp",
+            // but launched as `dotnet MemoryLens.Mcp.dll` the process name is just
+            // "dotnet" and the module path carries no assembly name, so the server would
+            // otherwise offer itself up for profiling.
+            .Where(p => p.Pid != Environment.ProcessId)
             .Where(p => !processFilter.IsExcluded(p.Name, p.CommandLine))
             .Where(p => filter == null ||
                         p.Name.Contains(filter, StringComparison.OrdinalIgnoreCase));
 
-        return JsonSerializer.Serialize(processes, new JsonSerializerOptions
+        return Task.FromResult(JsonSerializer.Serialize(processes, new JsonSerializerOptions
         {
             WriteIndented = true
-        });
-    }
-
-    private static IEnumerable<DotNetProcess> ParseProcessList(string output)
-    {
-        foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
-        {
-            var parts = line.Trim().Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
-            if (parts.Length >= 2 && int.TryParse(parts[0], CultureInfo.InvariantCulture, out var pid))
-            {
-                yield return new DotNetProcess(pid, parts[1].Trim(), "");
-            }
-        }
+        }));
     }
 }
-
-public record DotNetProcess(int Pid, string Name, string CommandLine);

--- a/tests/MemoryLens.Mcp.Tests/Integration/ToolIntegrationTests.cs
+++ b/tests/MemoryLens.Mcp.Tests/Integration/ToolIntegrationTests.cs
@@ -32,16 +32,12 @@ public class ToolIntegrationTests
     [Fact]
     public async Task ListProcesses_FiltersExcludedProcesses()
     {
-        var processOutput = """
-            1234 MyApp.Web
-            5678 devenv
-            9012 dotnet-dotmemory
-            3456 MyApp.Worker
-            """;
-
-        var runner = new FakeProcessRunner(exitCode: 0, output: processOutput);
-        var filter = new ProcessFilter();
-        var tool = new ListProcessesTool(runner, filter);
+        var lister = new FakeDotNetProcessLister(
+            new DotNetProcess(1234, "MyApp.Web", ""),
+            new DotNetProcess(5678, "devenv", ""),
+            new DotNetProcess(9012, "dotnet-dotmemory", ""),
+            new DotNetProcess(3456, "MyApp.Worker", ""));
+        var tool = new ListProcessesTool(lister, new ProcessFilter());
 
         var json = await tool.list_processes(ct: TestContext.Current.CancellationToken);
         var processes = JsonDocument.Parse(json).RootElement;
@@ -59,20 +55,67 @@ public class ToolIntegrationTests
     [Fact]
     public async Task ListProcesses_WithFilter_NarrowsResults()
     {
-        var processOutput = """
-            1234 MyApp.Web
-            3456 MyApp.Worker
-            7890 OtherApp.Service
-            """;
-
-        var runner = new FakeProcessRunner(exitCode: 0, output: processOutput);
-        var filter = new ProcessFilter();
-        var tool = new ListProcessesTool(runner, filter);
+        var lister = new FakeDotNetProcessLister(
+            new DotNetProcess(1234, "MyApp.Web", ""),
+            new DotNetProcess(3456, "MyApp.Worker", ""),
+            new DotNetProcess(7890, "OtherApp.Service", ""));
+        var tool = new ListProcessesTool(lister, new ProcessFilter());
 
         var json = await tool.list_processes(filter: "MyApp", ct: TestContext.Current.CancellationToken);
         var processes = JsonDocument.Parse(json).RootElement;
 
         Assert.Equal(2, processes.GetArrayLength());
+    }
+
+    /// <summary>
+    /// Guards the defect this replaced: the tool shelled out to
+    /// `dotnet dotmemory list-processes`. dotMemory Console has no process-listing
+    /// command at all, so the tool could never work — and it also made an unrelated
+    /// profiler install a prerequisite for merely listing processes.
+    /// </summary>
+    [Fact]
+    public async Task ListProcesses_NeedsNoProfilerInstalled()
+    {
+        var lister = new FakeDotNetProcessLister(new DotNetProcess(1234, "MyApp.Web", ""));
+
+        // No IProcessRunner and no DotMemoryToolManager: the tool cannot reach a CLI
+        // even if one were installed.
+        var tool = new ListProcessesTool(lister, new ProcessFilter());
+
+        var json = await tool.list_processes(ct: TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, JsonDocument.Parse(json).RootElement.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task ListProcesses_NoDotNetProcesses_ReturnsEmptyArray()
+    {
+        var tool = new ListProcessesTool(new FakeDotNetProcessLister(), new ProcessFilter());
+
+        var json = await tool.list_processes(ct: TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, JsonDocument.Parse(json).RootElement.GetArrayLength());
+    }
+
+    /// <summary>
+    /// ProcessFilter excludes the server by the name "MemoryLens.Mcp", which does not
+    /// match when it runs as `dotnet MemoryLens.Mcp.dll` — the process name is then
+    /// just "dotnet". Excluding by pid is what actually holds.
+    /// </summary>
+    [Fact]
+    public async Task ListProcesses_ExcludesItself_EvenWhenRunningAsPlainDotnet()
+    {
+        var lister = new FakeDotNetProcessLister(
+            new DotNetProcess(Environment.ProcessId, "dotnet", "/usr/share/dotnet/dotnet"),
+            new DotNetProcess(4321, "MyApp.Web", "/app/MyApp.Web"));
+        var tool = new ListProcessesTool(lister, new ProcessFilter());
+
+        var json = await tool.list_processes(ct: TestContext.Current.CancellationToken);
+        var processes = JsonDocument.Parse(json).RootElement;
+
+        var pids = processes.EnumerateArray().Select(p => p.GetProperty("Pid").GetInt32()).ToList();
+        Assert.DoesNotContain(Environment.ProcessId, pids);
+        Assert.Contains(4321, pids);
     }
 
     [Fact]

--- a/tests/MemoryLens.Mcp.Tests/Profiler/DiagnosticPortProcessListerTests.cs
+++ b/tests/MemoryLens.Mcp.Tests/Profiler/DiagnosticPortProcessListerTests.cs
@@ -1,0 +1,111 @@
+using System.Diagnostics;
+using MemoryLens.Mcp.Profiler;
+using Xunit;
+
+namespace MemoryLens.Mcp.Tests.Profiler;
+
+public class DiagnosticPortProcessListerTests
+{
+    [Theory]
+    // Real runtime form: pid, then a start-time disambiguator.
+    [InlineData("dotnet-diagnostic-1234-9876543-socket", true, 1234)]
+    [InlineData("dotnet-diagnostic-7-1-socket", true, 7)]
+    // Tolerate the disambiguator being absent.
+    [InlineData("dotnet-diagnostic-4242-socket", true, 4242)]
+    // Not endpoints.
+    [InlineData("dotnet-diagnostic-notapid-1234-socket", false, 0)]
+    [InlineData("dotnet-diagnostic-1234-socket.lock", false, 0)]
+    [InlineData("clr-debug-pipe-1234-socket", false, 0)]
+    [InlineData("dotnet-diagnostic-0-1-socket", false, 0)]
+    [InlineData("dotnet-diagnostic--1-1-socket", false, 0)]
+    [InlineData("", false, 0)]
+    public void TryParseUnixSocketPid_AcceptsOnlyRuntimeEndpoints(
+        string fileName, bool expected, int expectedPid)
+    {
+        var parsed = DiagnosticPortProcessLister.TryParseUnixSocketPid(fileName, out var pid);
+
+        Assert.Equal(expected, parsed);
+        Assert.Equal(expectedPid, pid);
+    }
+
+    [Theory]
+    [InlineData("dotnet-diagnostic-1234", true, 1234)]
+    [InlineData("dotnet-diagnostic-1", true, 1)]
+    // The pipe form carries no disambiguator, so a trailing segment is not a pid.
+    [InlineData("dotnet-diagnostic-1234-5678", false, 0)]
+    [InlineData("dotnet-diagnostic-", false, 0)]
+    [InlineData("dotnet-diagnostic-0", false, 0)]
+    [InlineData("some-other-pipe", false, 0)]
+    public void TryParseWindowsPipePid_AcceptsOnlyRuntimeEndpoints(
+        string pipeName, bool expected, int expectedPid)
+    {
+        var parsed = DiagnosticPortProcessLister.TryParseWindowsPipePid(pipeName, out var pid);
+
+        Assert.Equal(expected, parsed);
+        Assert.Equal(expectedPid, pid);
+    }
+
+    [Fact]
+    public void ListProcesses_MissingEndpointDirectory_ReturnsEmpty()
+    {
+        // Windows discovery reads the pipe namespace and ignores this directory, so
+        // there is no "missing directory" state to exercise there.
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var lister = new DiagnosticPortProcessLister(
+            Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")));
+
+        Assert.Empty(lister.ListProcesses());
+    }
+
+    /// <summary>
+    /// A socket left behind by an exited process must not be reported — the pid no
+    /// longer resolves, and callers would try to profile something that is gone.
+    /// </summary>
+    [Fact]
+    public void ListProcesses_StaleEndpoint_IsSkipped()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Windows discovery reads the pipe namespace, not this directory.
+
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        // A pid that cannot be live: allocated far above the practical maximum.
+        File.WriteAllText(Path.Combine(dir, "dotnet-diagnostic-2000000000-1-socket"), "");
+
+        try
+        {
+            var lister = new DiagnosticPortProcessLister(dir);
+            Assert.Empty(lister.ListProcesses());
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>
+    /// End-to-end against a real endpoint: this test process is a .NET process, so its
+    /// own pid must be discoverable through whichever mechanism the platform uses.
+    /// </summary>
+    [Fact]
+    public void ListProcesses_FindsTheCurrentProcess()
+    {
+        var lister = new DiagnosticPortProcessLister();
+
+        var pids = lister.ListProcesses().Select(p => p.Pid).ToList();
+
+        Assert.Contains(Environment.ProcessId, pids);
+    }
+
+    [Fact]
+    public void ListProcesses_ReportsTheProcessName()
+    {
+        var lister = new DiagnosticPortProcessLister();
+
+        var self = lister.ListProcesses().SingleOrDefault(p => p.Pid == Environment.ProcessId);
+
+        Assert.NotNull(self);
+        using var current = Process.GetCurrentProcess();
+        Assert.Equal(current.ProcessName, self.Name);
+    }
+}

--- a/tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryAutoInstallerTests.cs
+++ b/tests/MemoryLens.Mcp.Tests/Profiler/DotMemoryAutoInstallerTests.cs
@@ -40,6 +40,82 @@ public class DotMemoryAutoInstallerTests
         Assert.Null(result);
     }
 
+    public static TheoryData<string, byte[], bool> ExecutableHeaders => new()
+    {
+        // Shebang scripts — dotMemory.sh and the runtime-dotnet.sh it execs.
+        { "runtime-dotnet.sh", "#!/bin/sh\nexit 0\n"u8.ToArray(), true },
+        // Native ELF helper with a dotted name, which a filename rule misses.
+        { "JetBrains.Profiler.PdbServer", [0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01], true },
+        // Mach-O 64-bit, for the macOS packages.
+        { "dotmemory", [0xCF, 0xFA, 0xED, 0xFE, 0x0C, 0x00], true },
+        // Managed assembly: "MZ" header, launched through the host.
+        { "JetBrains.Lifetimes.dll", [0x4D, 0x5A, 0x90, 0x00], false },
+        { "dotmemory_clt_license.md", "# License\n"u8.ToArray(), false },
+        { "linux-x64.rel.Common.symref", "abc123"u8.ToArray(), false },
+        { "empty-file", [], false },
+    };
+
+    [Theory]
+    [MemberData(nameof(ExecutableHeaders))]
+    public void NeedsExecuteBit_DecidesFromFileHeader_NotFileName(
+        string fileName, byte[] contents, bool expected)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, fileName);
+        File.WriteAllBytes(path, contents);
+
+        try
+        {
+            Assert.Equal(expected, DotMemoryAutoInstaller.NeedsExecuteBit(path));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>
+    /// Guards the defect this replaced: only the entry point was chmodded, so the
+    /// runtime-dotnet.sh it execs failed with "Permission denied" on Linux and macOS.
+    /// </summary>
+    [Fact]
+    public void MakeToolsExecutable_SetsBitOnNestedScripts_NotJustTheEntryPoint()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Unix file modes are not meaningful here.
+
+        var versionDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var toolsDir = Path.Combine(versionDir, "tools");
+        var nativeDir = Path.Combine(toolsDir, "linux-x64");
+        Directory.CreateDirectory(nativeDir);
+
+        var entryPoint = Path.Combine(toolsDir, "dotMemory.sh");
+        var chainedScript = Path.Combine(toolsDir, "runtime-dotnet.sh");
+        var nativeHelper = Path.Combine(nativeDir, "JetBrains.Profiler.PdbServer");
+        var managedAssembly = Path.Combine(toolsDir, "JetBrains.Lifetimes.dll");
+
+        File.WriteAllText(entryPoint, "#!/bin/sh\nexec ./runtime-dotnet.sh\n");
+        File.WriteAllText(chainedScript, "#!/bin/sh\nexit 0\n");
+        File.WriteAllBytes(nativeHelper, [0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01]);
+        File.WriteAllBytes(managedAssembly, [0x4D, 0x5A, 0x90, 0x00]);
+
+        foreach (var path in new[] { entryPoint, chainedScript, nativeHelper, managedAssembly })
+        {
+            File.SetUnixFileMode(path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite |
+                UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+        }
+
+        try
+        {
+            DotMemoryAutoInstaller.MakeToolsExecutable(versionDir);
+
+            Assert.True(File.GetUnixFileMode(entryPoint).HasFlag(UnixFileMode.UserExecute));
+            Assert.True(File.GetUnixFileMode(chainedScript).HasFlag(UnixFileMode.UserExecute));
+            Assert.True(File.GetUnixFileMode(nativeHelper).HasFlag(UnixFileMode.UserExecute));
+            Assert.False(File.GetUnixFileMode(managedAssembly).HasFlag(UnixFileMode.UserExecute));
+        }
+        finally { Directory.Delete(versionDir, recursive: true); }
+    }
+
     [Fact]
     public async Task GetCachedPath_ReturnsNull_WhenCurrentTxtMissing()
     {

--- a/tests/MemoryLens.Mcp.Tests/Profiler/FakeDotNetProcessLister.cs
+++ b/tests/MemoryLens.Mcp.Tests/Profiler/FakeDotNetProcessLister.cs
@@ -1,0 +1,8 @@
+using MemoryLens.Mcp.Profiler;
+
+namespace MemoryLens.Mcp.Tests.Profiler;
+
+public class FakeDotNetProcessLister(params DotNetProcess[] processes) : IDotNetProcessLister
+{
+    public IReadOnlyList<DotNetProcess> ListProcesses() => processes;
+}


### PR DESCRIPTION
Follow-up to the finding flagged in #117. Investigating it surfaced a second, more serious bug in the same code path, so this PR carries two commits.

## 1. Execute bits across the extracted package

`ZipFile.ExtractToDirectory` discards Unix permission bits, so every file in the downloaded `.nupkg` lands as `0644`. The installer chmodded **only the entry point**, which cannot work — `dotMemory.sh` execs `runtime-dotnet.sh`, which execs a native host:

```
exec: /root/.memorylens/tools/dotmemory/2026.2.0/tools/runtime-dotnet.sh: Permission denied
```

**This made `snapshot`, `compare_snapshots` and `analyze` unusable on Linux and macOS** whenever the CLI came from the auto-installer — the tools that actually matter. It is the higher-impact half of this PR.

Executability is now decided from each file's **leading bytes** (shebang, ELF, or Mach-O) rather than its name. A filename rule does not work here, and my own test caught me getting this wrong first: JetBrains ships native helpers with dotted names like `JetBrains.Profiler.PdbServer`, so `Path.GetExtension` reports `".PdbServer"` and an "extensionless means native" test silently misses them. Managed assemblies start with `MZ` and are excluded for free.

The bits are re-applied on a **cache hit** too, so a cache already broken by the previous code self-heals rather than failing forever. Already-executable files are skipped so the walk stays cheap.

## 2. `list_processes` never could have worked

The tool shelled out to `dotnet dotmemory list-processes`. Two independent reasons that fails:

- **No shim exists.** The auto-installer unpacks `JetBrains.dotMemory.Console.<rid>` under `$HOME/.memorylens` and never registers a `dotnet-dotmemory` command, so the subcommand did not resolve even after `ensure_dotmemory` reported success. Confirmed on a Windows host too.
- **dotMemory has no process-listing command at all.** Its verbs are `get-snapshot`, `attach`, `start`, `start-net-core`, `recover`:

  ```
  'list-processes' is not a valid command. Valid: get-snapshot|attach|start|start-net-core|recover
  ```

So no change to *how* the CLI was invoked could have fixed this. My first attempt — routing through `DotMemoryToolManager` like `SnapshotManager` does — was abandoned once the second reason surfaced.

Replaced with `DiagnosticPortProcessLister`, which enumerates the diagnostic IPC endpoints every .NET Core 3.0+ runtime opens by default: `dotnet-diagnostic-{pid}-{disambiguator}-socket` under the temp directory, or `\.\pipe\dotnet-diagnostic-{pid}` on Windows. Same mechanism the `dotnet-*` diagnostic CLIs use. **Listing processes no longer requires a profiler**, so it works before `ensure_dotmemory` — the skill doc now says so.

Also fixes self-exclusion: `ProcessFilter` matched the name `"MemoryLens.Mcp"`, which does not hold when the server runs as `dotnet MemoryLens.Mcp.dll` — the name is then just `"dotnet"` and the module path carries no assembly name, so **the server offered itself up for profiling.** Now excluded by pid. Stale endpoints from exited processes are dropped rather than reported.

## Verification

137 tests pass (was 118). Beyond unit tests:

- **Windows**: pipe enumeration finds the test process and reports its name.
- **Linux container, no profiler installed, no `ensure_dotmemory`**: returns real results.
- **Self-exclusion**: with only the server running, returns `[]` rather than itself.
- **Cross-container discovery**: with a shared PID namespace *and* `/tmp`, discovers another container's runtime via socket `dotnet-diagnostic-1-21381887-socket` — exercising the real disambiguator format.
- **Permission fix**: verified against a cache the old code had already broken, confirming self-heal.

## Note for #117

Worth adding to `docs/docker.md` on that branch: in containers, `--pid=host` alone is **not** sufficient for `list_processes`. The diagnostic socket lives in the target's `/tmp`, which a PID namespace does not share, so the temp directory must be shared too. I found this while verifying and did not want to create a cross-branch conflict; happy to push it to #117 instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)