### PR TITLE
fix(ci): retry MCP Registry publish, re-authenticating each attempt

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -21,8 +21,31 @@ jobs:
           tar xzf mcp-publisher.tar.gz
           chmod +x mcp-publisher
 
-      - name: Authenticate via OIDC
-        run: ./mcp-publisher login github-oidc
-
       - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
+        # Retry with backoff in case NuGet is still indexing the version the registry
+        # validates against (~25 min window), so a manual re-run does not have to be
+        # timed by hand. Safe to run any time: succeeds on the first attempt once the
+        # version is indexed.
+        #
+        # Authentication happens INSIDE the loop because the registry JWT expires a few
+        # minutes after it is minted, well inside this window. A token taken once up
+        # front would make every later attempt a guaranteed 401 that the loop then
+        # blamed on NuGet indexing lag.
+        run: |
+          max_attempts=15
+          delay=30
+          for attempt in $(seq 1 "$max_attempts"); do
+            if ! ./mcp-publisher login github-oidc; then
+              echo "::warning::OIDC login failed on attempt $attempt/$max_attempts."
+            elif ./mcp-publisher publish; then
+              echo "Published to MCP Registry on attempt $attempt."
+              exit 0
+            fi
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "::notice::MCP Registry publish attempt $attempt/$max_attempts failed (NuGet may still be indexing); retrying in ${delay}s"
+              sleep "$delay"
+              [ "$delay" -lt 120 ] && delay=$((delay + 30))
+            fi
+          done
+          echo "::error::MCP Registry publish failed after $max_attempts attempts (~25 min)."
+          exit 1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -86,8 +86,37 @@ jobs:
           tar xzf mcp-publisher.tar.gz
           chmod +x mcp-publisher
 
-      - name: Authenticate via OIDC
-        run: ./mcp-publisher login github-oidc
-
       - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
+        # The registry validates the version against NuGet's search index, which for a
+        # NEW version can lag 5-15+ min behind the upload the `publish` job just did
+        # (new versions index far slower than updates to an existing package). A single
+        # attempt therefore fails the release on indexing lag and leaves the registry
+        # entry stale until someone re-runs the workflow by hand. Retry with backoff
+        # over a ~25 min window so we ride it out.
+        #
+        # Authentication happens INSIDE the loop, and that is load-bearing. The registry
+        # JWT expires a few minutes after it is minted, which is well inside this
+        # window, so a token taken once up front would make every attempt past roughly
+        # the fifth a guaranteed 401 "token is expired" while the loop reported the
+        # failure as NuGet indexing lag.
+        env:
+          VERSION: ${{ needs.release-please.outputs.version }}
+        run: |
+          max_attempts=15
+          delay=30
+          for attempt in $(seq 1 "$max_attempts"); do
+            if ! ./mcp-publisher login github-oidc; then
+              echo "::warning::OIDC login failed on attempt $attempt/$max_attempts."
+            elif ./mcp-publisher publish; then
+              echo "Published $VERSION to MCP Registry on attempt $attempt."
+              exit 0
+            fi
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "::notice::MCP Registry publish attempt $attempt/$max_attempts failed (NuGet is likely still indexing $VERSION); retrying in ${delay}s"
+              sleep "$delay"
+              # Ramp up to a 2 min cap so the total window is ~25 min without hammering.
+              [ "$delay" -lt 120 ] && delay=$((delay + 30))
+            fi
+          done
+          echo "::error::MCP Registry publish failed after $max_attempts attempts (~25 min). NuGet may still be indexing $VERSION; once nuget.org shows it, re-run the 'Publish to MCP Registry' workflow (Actions -> Publish to MCP Registry -> Run workflow)."
+          exit 1


### PR DESCRIPTION
Companion to MarcelRoozekrans/roslyn-codelens-mcp#352, but the bug here is the opposite shape — worth reading before assuming it is the same change.

## This repo had no retry at all

roslyn-codelens has a retry loop with an expiring token. This repo publishes in **a single attempt**:

```yaml
- name: Authenticate via OIDC
  run: ./mcp-publisher login github-oidc

- name: Publish to MCP Registry
  run: ./mcp-publisher publish
```

The registry validates a release against NuGet's search index, and a **new** version can take 5–15+ minutes to appear. Any release landing inside that lag fails outright and leaves the registry entry stale until someone re-runs the workflow by hand — which is what has been happening.

## The fix

Adds the backoff retry over a ~25 minute window, with authentication **inside** the loop from the start.

That placement is the whole point rather than a detail: the registry JWT expires a few minutes after it is minted, well inside the window. Adding the loop with the login left outside would reproduce roslyn-codelens's bug exactly — every attempt past roughly the fifth returning `401 token is expired` while the log blames NuGet indexing. This adds the retry already correct instead of adding it and then repairing it.

Applied to both `release-please.yml` and `publish-mcp-registry.yml`, so a hand-triggered re-run no longer has to be timed against NuGet indexing either.

## Verification

Workflow YAML parses, and an assertion confirms both `mcp-publisher` scripts have their login inside the retry loop with no leftover standalone login step.

The loop was extracted and run against a stubbed publisher:

| Scenario | Exit | Logins | Publishes |
|---|---|---|---|
| Succeeds first try | 0 | 1 | 1 |
| Succeeds on 4th (indexing lag) | 0 | **4** | 4 |
| Never succeeds | 1 | 15 | 15 |
| Login always fails | 1 | 15 | **0** |

Row 1 matters here: adding a retry must not slow down the normal case, and it does not — one login, one publish, no waiting. Row 2 shows a fresh token per attempt.

## Unrelated

This repo has **zero failing workflow runs**, so Glama's "CI is failing" note on its score card is stale rather than something to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)