### PR TITLE
fix(ci): opt in to the MTP runner so dotnet test works on .NET 10 SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}


### PR DESCRIPTION
## The problem

CI has been red on `main` since 2026-08-15 — 8 consecutive failed runs, and every Renovate PR since (including the open #149) fails for the same reason rather than for anything to do with its own dependency bump.

`dda705a chore(deps): update xunit-dotnet monorepo to v4 (#143)` bumped `xunit.v3` to 4.0.0, which pulls in `Microsoft.Testing.Platform` v2. MTP v2 removed the VSTest bridge and now hard-errors when invoked through the legacy VSTest target on a .NET 10 SDK:

```
Microsoft.Testing.Platform.MSBuild.targets(320,5): error : Testing with VSTest target is
no longer supported by Microsoft.Testing.Platform on .NET 10 SDK and later.
```

The repo has no `global.json`, so `dotnet test` still defaults to VSTest mode — it fails before a single test runs. The tests themselves are fine.

This also blocks releases: `release-please.yml` runs `dotnet test -c Release --no-build` before packing.

## The fix

Add `global.json` at the repo root with the documented .NET 10 opt-in:

```json
{
  "test": {
    "runner": "Microsoft.Testing.Platform"
  }
}
```

The `sdk` section is deliberately omitted so this does not pin an SDK version.

## Verification

Reproduced the failure in a clean worktree at `origin/main` on SDK 10.0.400, then confirmed the fix with the full CI sequence:

```
dotnet restore
dotnet build --no-restore -c Release      → Build succeeded. 8 Warning(s), 0 Error(s)
dotnet test --no-build -c Release --verbosity normal

  Test run summary: Passed!
    total: 137
    failed: 0
    succeeded: 137
    skipped: 0
```

No workflow edits are needed — `--no-build`, `-c` and `--verbosity` are all accepted in MTP mode.

## Follow-ups (not in this PR)

- `Microsoft.NET.Test.Sdk` and `xunit.runner.visualstudio` are VSTest-only and now dead weight in the test project. Removing both works, but requires adding `<OutputType>Exe</OutputType>` — `Microsoft.NET.Test.Sdk` was implicitly setting it, and xunit.v3 v4 errors without it. Verified green, kept out of this PR to keep the unblock minimal.
- `main` has branch protection requiring the `build` check, but `enforce_admins` is off — which is how six red commits landed on `main` anyway. Worth turning on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
