### PR TITLE
ci: rig guards so a broken test rig cannot go unnoticed (phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -47,3 +50,43 @@ jobs:
       - name: Push to NuGet (pre-release)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: dotnet nuget push ./artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+  alert:
+    needs: [build]
+    if: always() && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      SHA: ${{ github.sha }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Open or update the red-main issue
+        if: needs.build.result == 'failure'
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --label ci-red --state open --json number --jq '.[0].number // empty')
+          body=$(printf 'CI failed on `main` at %s.\n\nRun: %s\n' "$SHA" "$RUN_URL")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+            echo "Commented on existing issue #$existing"
+          else
+            gh issue create --title "CI is red on main" --label ci-red --body "$body"
+            echo "Opened a new ci-red issue"
+          fi
+
+      - name: Close the red-main issue on recovery
+        if: needs.build.result == 'success'
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --label ci-red --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$(printf 'Recovered on %s.\n\nRun: %s\n' "$SHA" "$RUN_URL")"
+            gh issue close "$existing"
+            echo "Closed issue #$existing"
+          else
+            echo "No open ci-red issue; nothing to close"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 10.0.x
+          global-json-file: ./global.json
 
       - name: Restore tools
         run: dotnet tool restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Open or update the red-main issue
-        if: needs.build.result == 'failure'
+        if: needs.build.result != 'success'
         run: |
           set -euo pipefail
           existing=$(gh issue list --label ci-red --state open --json number --jq '.[0].number // empty')

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 10.0.x
+          global-json-file: ./global.json
 
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 10.0.x
+          global-json-file: ./global.json
 
       - name: Restore tools
         run: dotnet tool restore

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ WORKDIR /src
 
 # Restore against the project file alone so the (slow) restore layer survives
 # source-only edits. Directory.Build.props carries the shared analyzer set.
+#
+# global.json is deliberately NOT copied in: it pins 10.0.400 with
+# rollForward: latestPatch, and the floating sdk:10.0 tag above will
+# eventually roll forward to a 10.0.5xx feature band. Copying the pin in
+# would then hard-break the build ("compatible SDK version not found")
+# instead of just picking up the newer SDK, as it does today.
 COPY Directory.Build.props ./
 COPY src/MemoryLens.Mcp/MemoryLens.Mcp.csproj src/MemoryLens.Mcp/
 RUN dotnet restore src/MemoryLens.Mcp/MemoryLens.Mcp.csproj

--- a/README.md
+++ b/README.md
@@ -92,8 +92,13 @@ Docker Desktop that namespace is the Linux VM rather than your desktop — see
 
 ## Prerequisites
 
-- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) or later
+- [.NET 10 SDK](https://dotnet.microsoft.com/download/dotnet/10.0), 10.0.4xx feature band (pinned in `global.json`)
 - JetBrains dotMemory CLI (see below for installation options)
+
+Running a filtered subset of the tests, e.g. `dotnet test --filter <name>`, will exit with code 9
+and print `error: 1, failed: 0`. That's the test project's discovery-collapse guard
+(`--minimum-expected-tests 130`) firing because the filter left fewer tests than expected — it is
+not a test failure, and a full `dotnet test` run is unaffected.
 
 ## dotMemory CLI Installation
 

--- a/global.json
+++ b/global.json
@@ -1,4 +1,8 @@
 {
+  "sdk": {
+    "version": "10.0.400",
+    "rollForward": "latestPatch"
+  },
   "test": {
     "runner": "Microsoft.Testing.Platform"
   }

--- a/tests/MemoryLens.Mcp.Tests/MemoryLens.Mcp.Tests.csproj
+++ b/tests/MemoryLens.Mcp.Tests/MemoryLens.Mcp.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TestingPlatformCommandLineArguments>--minimum-expected-tests 130</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Phase 1 of `docs/superpowers/specs/2026-08-21-testing-rig-hardening-design.md` (spec + plan in #TBD).

## Why

CI failed on `main` for eight consecutive runs and stayed red for six days (#150). The failure was **loud from the very first run** — nothing was listening. That is the hole this closes.

Three guards here; the fourth (`enforce_admins`) is deliberately deferred until after this merges, since enabling it first would gate the very PR that introduces it. Tracked separately.

## What

| Guard | Change |
|---|---|
| **Discovery-collapse floor** | `--minimum-expected-tests 130` on the test project, so a run that discovers **zero** tests fails loudly instead of reporting success |
| **SDK pin** | `global.json` pins `10.0.400` / `latestPatch`; all three workflows switched from `dotnet-version: 10.0.x` to `global-json-file` |
| **Red-main alert** | New `alert` job opens a `ci-red` issue when `main` breaks and closes it on recovery |

## Verification — this was fire-drilled, not just written

An alert that never fires is worse than none, because you believe you're covered. So it was tested live on a throwaway branch:

- **Failure run** ([32512719243](https://github.com/MarcelRoozekrans/memorylens-mcp/actions/runs/32512719243)) — `build` failed, `alert` **ran** and opened issue #152.
- **Recovery run** ([32512829667](https://github.com/MarcelRoozekrans/memorylens-mcp/actions/runs/32512829667)) — `build` passed, `alert` closed #152.

Both red and green paths for the test floor and the SDK pin were also verified against the real toolchain before the code was written.

The drill also answered an open question: **SDK 10.0.400 is already present on the `ubuntu-24.04` runner image**, so `global-json-file` needs no download.

## Design notes worth reviewing

**The alert condition is `needs.build.result != 'success'`, not `== 'failure'`.** This is deliberate. A `cancelled` or `skipped` build would otherwise alert nobody — and once Phase 2 lands the 3-OS matrix, a fail-fast leg *cancels* its siblings, making that routine rather than rare.

**The required check `build` is untouched.** Not renamed, not matrix-ised. Branch protection requires the context `build`; matrix-ising it would rename the checks to `build (ubuntu-latest)` etc. and strand every PR on a required check that never reports. Phase 2 introduces the matrix as a *separate* job with `build` surviving as an aggregating gate.

**The test floor is unconditional, on purpose.** It means `dotnet test --filter ...` exits 9 locally with `error: 1, failed: 0`. Making it CI-conditional was considered and rejected: every mechanism for doing so creates a guard that can silently fail to apply, which is the exact failure mode this PR exists to eliminate. Documented in the README instead.

**`permissions: contents: read` was added at workflow level.** Verified this does not break the release path — `build` never uses `GITHUB_TOKEN`, GitVersion needs only read, and the NuGet push authenticates with a step-level secret. Pack ran green under the new block during the drill.

**The Dockerfile deliberately does not copy `global.json`.** It builds on the floating `sdk:10.0` tag; copying the `latestPatch` pin would hard-break the image the moment that tag rolls to a `10.0.5xx` band. A comment now records this so nobody "fixes" it.

## Not included

- `enforce_admins` — after this merges (tracking issue linked below).
- Real integration tests — Phase 2. This PR closes the "rig stopped running" hole; it does nothing for the "rig runs but tests nothing real" hole that let #118 ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
