### PR TITLE
docs: testing rig hardening — design and phase 1 plan

### DIFF
--- a/docs/superpowers/plans/2026-08-21-rig-guards-phase-1.md
+++ b/docs/superpowers/plans/2026-08-21-rig-guards-phase-1.md
@@ -1,0 +1,471 @@
+# Rig Guards (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make it impossible for the test rig to silently stop running, and impossible for `main` to stay red without someone being told.
+
+**Architecture:** Four independent guards, no new projects and no new test code. A minimum-test-count floor so a collapse in test discovery fails loudly; an SDK pin so runner-side SDK drift cannot change build behaviour with no repo change; a CI job that opens or updates a single GitHub issue when `main` goes red and closes it on recovery; and `enforce_admins` on branch protection so red commits cannot be merged past the required check.
+
+**Tech Stack:** .NET 10 SDK, Microsoft.Testing.Platform, xunit.v3 4.0.0, GitHub Actions, `gh` CLI.
+
+**Spec:** `docs/superpowers/specs/2026-08-21-testing-rig-hardening-design.md`
+
+## Global Constraints
+
+- Target framework is `net10.0`. Do not change it.
+- The required branch-protection status check is named exactly **`build`**. Do not rename, delete, or matrix-ise the `build` job in this phase. Phase 2 introduces the matrix; Phase 1 must leave the check name untouched.
+- SDK pin is `10.0.400` with `rollForward: latestPatch` — locks the `10.0.4xx` feature band, still takes patches.
+- Minimum-expected-tests floor for `MemoryLens.Mcp.Tests` is `130` (against 137 actual). It is a floor, not an exact count.
+- The `global.json` `test.runner` key must be preserved exactly as `Microsoft.Testing.Platform`. Removing it re-breaks `dotnet test` (see #150).
+- Alert issue label is `ci-red`. One issue, many comments — never one issue per failure.
+- Commit messages follow Conventional Commits; release-please parses them.
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `tests/MemoryLens.Mcp.Tests/MemoryLens.Mcp.Tests.csproj` | Modify | Carries the `--minimum-expected-tests` floor for this test application |
+| `global.json` | Modify | Pins the SDK feature band; already carries the MTP runner opt-in |
+| `.github/workflows/ci.yml` | Modify | Switches to `global-json-file`; adds the `alert` job and explicit permissions |
+| `.github/workflows/release.yml` | Modify | Switches to `global-json-file` |
+| `.github/workflows/release-please.yml` | Modify | Switches to `global-json-file` |
+| GitHub repo settings | Modify | `ci-red` label; `enforce_admins` on `main` |
+
+Tasks 1–3 are code and land as one PR. Task 4 is a repository settings change applied outside the PR.
+
+## Before you start
+
+Work on a branch off current `main`:
+
+```bash
+git fetch origin
+git checkout -b ci/rig-guards origin/main
+```
+
+Everywhere below that says "the working branch", it means `ci/rig-guards`. The design spec lives on a separate branch (`docs/testing-rig-hardening`) and is not needed to execute this plan.
+
+---
+
+### Task 1: Minimum expected test count
+
+**Files:**
+- Modify: `tests/MemoryLens.Mcp.Tests/MemoryLens.Mcp.Tests.csproj:3-7` (the `PropertyGroup`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the MSBuild property `TestingPlatformCommandLineArguments`, which Tasks 2–4 do not touch. Phase 2's new test projects each get their own copy of this property with their own floor.
+
+**Background for the implementer:** Microsoft.Testing.Platform reads extra CLI arguments from the `TestingPlatformCommandLineArguments` MSBuild property. `--minimum-expected-tests N` makes the test application exit non-zero if fewer than N tests ran. This guards the dangerous failure mode where test discovery silently breaks and a run reporting "0 tests, success" looks green. The property is **per test application**, not per solution.
+
+- [ ] **Step 1: Write the failing guard — set the floor deliberately too high**
+
+In `tests/MemoryLens.Mcp.Tests/MemoryLens.Mcp.Tests.csproj`, add the last line to the existing `PropertyGroup`:
+
+```xml
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TestingPlatformCommandLineArguments>--minimum-expected-tests 999</TestingPlatformCommandLineArguments>
+  </PropertyGroup>
+```
+
+- [ ] **Step 2: Run tests to verify the guard fires**
+
+Run: `dotnet test -c Release`
+
+Expected: FAIL. The distinctive shape is a *platform* error rather than a test failure — note `error: 1` alongside `failed: 0`:
+
+```
+Test run summary: Failed!
+  error: 1
+  failed: 0
+Test run completed with non-success exit code: 9
+```
+
+If you instead see `Passed!`, the property is not being read — check it is inside a `PropertyGroup` in the **test** project, not `Directory.Build.props`.
+
+- [ ] **Step 3: Set the real floor**
+
+Change `999` to `130`:
+
+```xml
+    <TestingPlatformCommandLineArguments>--minimum-expected-tests 130</TestingPlatformCommandLineArguments>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test -c Release`
+
+Expected: PASS.
+
+```
+Test run summary: Passed!
+  total: 137
+  failed: 0
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/MemoryLens.Mcp.Tests/MemoryLens.Mcp.Tests.csproj
+git commit -m "test: fail the run if test discovery collapses
+
+Sets a --minimum-expected-tests floor of 130 against 137 actual, so a run
+that discovers zero tests fails loudly instead of reporting success. A floor
+rather than an exact count, so adding tests never requires a bump."
+```
+
+---
+
+### Task 2: SDK pin and deterministic runner install
+
+**Files:**
+- Modify: `global.json` (whole file)
+- Modify: `.github/workflows/ci.yml:20-22`
+- Modify: `.github/workflows/release.yml:18-20`
+- Modify: `.github/workflows/release-please.yml:38-40`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: a `global.json` containing both an `sdk` and a `test` section. Task 3 does not modify `global.json`.
+
+**Background for the implementer:** `global.json` currently pins nothing — the runner installs whatever `10.0.x` is newest, so build behaviour can change with no repo commit. `rollForward: latestPatch` locks the feature band (`10.0.4xx`) while still accepting bugfix patches; feature bands are where behaviour changes land. Switching `setup-dotnet` from `dotnet-version` to `global-json-file` is what actually makes CI deterministic — the pin alone does nothing if the runner installs something else and rolls forward.
+
+**Do not drop the `test` section.** Removing it re-breaks `dotnet test` exactly as in #150.
+
+- [ ] **Step 1: Write the failing check — pin to a version that does not exist**
+
+Replace the whole of `global.json` with:
+
+```json
+{
+  "sdk": {
+    "version": "10.0.999",
+    "rollForward": "latestPatch"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}
+```
+
+- [ ] **Step 2: Run the SDK resolver to verify it refuses**
+
+Run: `dotnet --version`
+
+Expected: FAIL — the SDK cannot resolve the pin. The message is confusingly worded but the failure is real:
+
+```
+The command could not be loaded, possibly because:
+  * You intended to execute a .NET application:
+```
+
+This confirms the pin is genuinely being honoured rather than ignored.
+
+- [ ] **Step 3: Set the real pin**
+
+Replace the whole of `global.json` with:
+
+```json
+{
+  "sdk": {
+    "version": "10.0.400",
+    "rollForward": "latestPatch"
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}
+```
+
+- [ ] **Step 4: Verify resolution and that tests still run**
+
+Run: `dotnet --version`
+Expected: `10.0.400`
+
+Run: `dotnet test -c Release`
+Expected: `Test run summary: Passed!` with `total: 137` — proving the `test` section survived the rewrite.
+
+- [ ] **Step 5: Point all three workflows at global.json**
+
+In each of `.github/workflows/ci.yml`, `.github/workflows/release.yml`, and `.github/workflows/release-please.yml`, replace the `with:` block of the `actions/setup-dotnet@v6` step.
+
+Before:
+
+```yaml
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+```
+
+After:
+
+```yaml
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: ./global.json
+```
+
+There are exactly three occurrences, one per file. Verify with `grep -n "dotnet-version" .github/workflows/*.yml` — expected output: no matches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add global.json .github/workflows/ci.yml .github/workflows/release.yml .github/workflows/release-please.yml
+git commit -m "build: pin the SDK feature band and install it from global.json
+
+Runner-side SDK bumps could change build behaviour with no repo change at
+all, which is hard to diagnose because git log shows nothing. latestPatch
+locks the 10.0.4xx band while still taking patches, and setup-dotnet now
+installs from global.json instead of resolving 10.0.x to whatever is newest.
+
+Does not address the #150 break, which came from the xunit v4 bump meeting
+an SDK major already in use."
+```
+
+---
+
+### Task 3: Red-main alert
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (add top-level `permissions`, add the `alert` job)
+- Create: the `ci-red` GitHub label (via `gh`, not a file)
+
+**Interfaces:**
+- Consumes: the existing job id `build` in `ci.yml`. Does not rename it.
+- Produces: a job id `alert` with `needs: [build]`. **Phase 2 must add `test` to that `needs` list and to the result checks when the matrix job is introduced** — otherwise a failing matrix leg skips `build` and the alert stops firing.
+
+**Background for the implementer:** This is the guard that would actually have prevented the six-day outage — the MTP failure was loud from the first run and nothing was listening.
+
+The condition must **not** be a bare `if: failure()`. When a needed job is skipped rather than failed, a dependent job can be skipped along with it, producing an alert that silently never fires in exactly the case it exists for. Always use `always()` plus explicit `needs.<job>.result` checks.
+
+Branch scoping comes from `on.push.branches`, not from a `github.ref` check in the job condition. That is deliberate: it keeps the job testable by temporarily adding a branch to the trigger (Step 5).
+
+- [ ] **Step 1: Create the label**
+
+Run:
+
+```bash
+gh label create ci-red --color b60205 --description "CI is failing on main"
+```
+
+Verify: `gh label list | grep ci-red`
+Expected: a `ci-red` row. The repo has no such label today.
+
+- [ ] **Step 2: Add explicit permissions and the alert job to ci.yml**
+
+`ci.yml` has no `permissions:` block today and so inherits the repo default. Add an explicit top-level block immediately after the `on:` block and before `jobs:`:
+
+```yaml
+permissions:
+  contents: read
+```
+
+Then append this job at the end of `.github/workflows/ci.yml`, at the same indentation as the existing `build:` job:
+
+```yaml
+  alert:
+    needs: [build]
+    if: always() && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_REPO: ${{ github.repository }}
+      SHA: ${{ github.sha }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Open or update the red-main issue
+        if: needs.build.result == 'failure'
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --label ci-red --state open --json number --jq '.[0].number // empty')
+          body=$(printf 'CI failed on `main` at %s.\n\nRun: %s\n' "$SHA" "$RUN_URL")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+            echo "Commented on existing issue #$existing"
+          else
+            gh issue create --title "CI is red on main" --label ci-red --body "$body"
+            echo "Opened a new ci-red issue"
+          fi
+
+      - name: Close the red-main issue on recovery
+        if: needs.build.result == 'success'
+        run: |
+          set -euo pipefail
+          existing=$(gh issue list --label ci-red --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$(printf 'Recovered on %s.\n\nRun: %s\n' "$SHA" "$RUN_URL")"
+            gh issue close "$existing"
+            echo "Closed issue #$existing"
+          else
+            echo "No open ci-red issue; nothing to close"
+          fi
+```
+
+`GH_REPO` is set because no checkout runs in this job — without it `gh` cannot tell which repository it is operating on.
+
+- [ ] **Step 3: Verify the YAML parses**
+
+Run: `python -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('ok')"`
+Expected: `ok`
+
+This catches indentation errors only. Steps 5–6 are the real verification.
+
+- [ ] **Step 4: Commit the alert job before drilling it**
+
+Commit on the working branch **first**. If you branch off with this change uncommitted, the drill branch takes it with you and the working branch loses the alert job when you switch back.
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: open an issue when main goes red, close it on recovery
+
+The MTP break was loud from the first run and stayed red for six days
+because nothing was listening. One issue labelled ci-red accumulates a
+comment per failure rather than spawning an issue per failure, and a green
+run on main closes it.
+
+The condition is always() plus explicit needs.build.result checks, not a
+bare failure(): a skipped dependency would otherwise skip the alert in
+exactly the case it exists for.
+
+Phase 2 must add the new matrix job to needs and to the result checks."
+```
+
+- [ ] **Step 5: Fire drill — prove the alert actually fires**
+
+An alert that never fires is worse than no alert, because you believe you are covered. Verify it live on a scratch branch. Do **not** skip this step.
+
+```bash
+git checkout -b ci/alert-fire-drill
+```
+
+Add the drill branch to the push trigger in `.github/workflows/ci.yml`:
+
+```yaml
+on:
+  push:
+    branches: [main, ci/alert-fire-drill]
+  pull_request:
+    branches: [main]
+```
+
+Now break the build deliberately by raising the floor from Task 1 above the actual count:
+
+```bash
+sed -i 's|--minimum-expected-tests 130|--minimum-expected-tests 999|' tests/MemoryLens.Mcp.Tests/MemoryLens.Mcp.Tests.csproj
+git commit -am "test: deliberate failure for alert fire drill"
+git push -u origin ci/alert-fire-drill
+```
+
+Watch: `gh run watch`
+
+Expected: the `build` job fails, and the `alert` job **runs** (not skips) and reports `Opened a new ci-red issue`.
+
+Verify: `gh issue list --label ci-red --state open`
+Expected: one open issue titled "CI is red on main".
+
+- [ ] **Step 6: Fire drill — prove recovery closes the issue**
+
+```bash
+sed -i 's|--minimum-expected-tests 999|--minimum-expected-tests 130|' tests/MemoryLens.Mcp.Tests/MemoryLens.Mcp.Tests.csproj
+git commit -am "test: restore the floor"
+git push
+```
+
+Watch: `gh run watch`
+
+Expected: `build` succeeds and the alert job reports `Closed issue #<n>`.
+
+Verify: `gh issue list --label ci-red --state open`
+Expected: no results.
+
+- [ ] **Step 7: Tear down the drill**
+
+```bash
+git checkout ci/rig-guards
+git branch -D ci/alert-fire-drill
+git push origin --delete ci/alert-fire-drill
+```
+
+Confirm the drill did not leak onto the working branch:
+
+Run: `grep -n "branches:" .github/workflows/ci.yml`
+Expected: only `[main]` — no `ci/alert-fire-drill`. Shipping that trigger would make every push to that branch name run CI.
+
+Run: `grep -n "minimum-expected-tests" tests/MemoryLens.Mcp.Tests/MemoryLens.Mcp.Tests.csproj`
+Expected: `130`, not `999`.
+
+Run: `git status --short`
+Expected: clean. The alert job is already committed from Step 4; both drill commits live only on the deleted branch.
+
+---
+
+### Task 4: Enable `enforce_admins`
+
+**Files:**
+- No repository files. This is a GitHub settings change.
+
+**Interfaces:**
+- Consumes: the existing branch protection on `main`, which already requires the `build` check.
+- Produces: nothing later tasks depend on.
+
+**Background for the implementer:** Branch protection already requires the `build` check, but `enforce_admins` is off — which is how six red commits reached `main` during the outage. Verified that no workflow pushes directly to `main` (release-please operates through PRs and tags), so automation is unaffected.
+
+**Do this last**, after Tasks 1–3 have merged, so the phase's own PR does not have to fight a rule that was just switched on.
+
+**Consequence the repo owner must accept:** they lose the ability to merge a red PR or push straight to `main`, including when they are certain it is fine. That is the point of the change, but it is a real change to how they work on their own repo.
+
+- [ ] **Step 1: Record the current state so the change is reversible**
+
+Run:
+
+```bash
+gh api repos/MarcelRoozekrans/memorylens-mcp/branches/main/protection/enforce_admins
+```
+
+Expected: `"enabled": false`
+
+- [ ] **Step 2: Enable it**
+
+```bash
+gh api -X POST repos/MarcelRoozekrans/memorylens-mcp/branches/main/protection/enforce_admins
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+gh api repos/MarcelRoozekrans/memorylens-mcp/branches/main/protection/enforce_admins --jq '.enabled'
+```
+
+Expected: `true`
+
+**Verification limit, stated honestly:** this confirms the setting is on. It does not prove a red merge is blocked, because proving that would mean deliberately pushing a red commit at `main` — which is precisely what the setting exists to prevent. The read-back is the appropriate level of verification here.
+
+To revert at any time:
+
+```bash
+gh api -X DELETE repos/MarcelRoozekrans/memorylens-mcp/branches/main/protection/enforce_admins
+```
+
+- [ ] **Step 4: Nothing to commit**
+
+This task changes no files. Do not create an empty commit.
+
+---
+
+## Done when
+
+- `dotnet test -c Release` passes locally and in CI with the floor active.
+- `dotnet --version` reports `10.0.400` in the repo root.
+- `grep -n "dotnet-version" .github/workflows/*.yml` returns no matches.
+- The fire drill has opened and then closed a `ci-red` issue.
+- `enforce_admins` reads back `true`.
+- No `ci/alert-fire-drill` branch remains, locally or on the remote.
+
+## Handoff to Phase 2
+
+Phase 2 introduces the `test` matrix job. It **must** update the `alert` job's `needs: [build]` to `needs: [test, build]` and add `needs.test.result == 'failure'` to the open-issue condition, plus require `needs.test.result == 'success'` for the recovery step. Leaving `needs` at `[build]` would mean a failing matrix leg skips `build` and the alert never fires.

--- a/docs/superpowers/specs/2026-08-21-testing-rig-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-21-testing-rig-hardening-design.md
@@ -1,0 +1,368 @@
+# Testing Rig Hardening — Design
+
+**Date:** 2026-08-21
+**Status:** Approved for planning
+**Author:** Marcel Roozekrans (with Claude)
+
+## Context
+
+Two independent failures escaped the current testing rig within a month of each
+other. They are different in kind, and fixing one does nothing for the other.
+
+### Escape 1 — the rig stopped running, and nobody noticed
+
+`dda705a` (#143, 2026-08-15) bumped `xunit.v3` to 4.0.0, which pulls in
+Microsoft.Testing.Platform v2. MTP v2 removed the VSTest bridge and hard-errors
+when invoked through the legacy VSTest target on a .NET 10 SDK. The repo had no
+`global.json`, so `dotnet test` still defaulted to VSTest mode:
+
+```
+Microsoft.Testing.Platform.MSBuild.targets(320,5): error : Testing with VSTest
+target is no longer supported by Microsoft.Testing.Platform on .NET 10 SDK and
+later.
+```
+
+CI failed on `main` for eight consecutive runs, and `main` stayed red for six
+days until #150 landed on 2026-08-21. Every Renovate PR in that window failed for
+the same reason rather than for its own dependency change. `release-please` also runs `dotnet test`, so releases were blocked too.
+Fixed in #150 by adding `global.json` with the MTP runner opt-in.
+
+The failure was loud from the first run. Nothing was listening.
+
+### Escape 2 — the rig ran fine and tested nothing real
+
+`dccd733` (#118) records the other shape:
+
+> `ZipFile.ExtractToDirectory` discards Unix permission bits, so every file in
+> the downloaded `.nupkg` lands as 0644. The installer chmodded only the entry
+> point, which is not enough: `dotMemory.sh` execs `runtime-dotnet.sh`, which
+> execs a native host, and the chain died on the second hop with
+> `exec: .../runtime-dotnet.sh: Permission denied`.
+
+Three of six tools — `snapshot`, `compare_snapshots`, `analyze` — were unusable
+on Linux and macOS. All 137 tests were green throughout, and necessarily so.
+
+### Why the current suite could not have caught either
+
+Verified against the tree at `ae0e957`:
+
+- **No test spawns a real process.** Zero hits for `Process.Start` or
+  `new ProcessRunner()` under `tests/`. Everything routes through
+  `FakeProcessRunner`, which never execs anything — so a missing execute bit is
+  structurally invisible.
+- **No test touches `Program.cs`, the DI container, or the MCP protocol.** Zero
+  hits for `CreateApplicationBuilder`, `IHost`, or `ServiceProvider`. The server
+  entry point, DI wiring, and tool-registration surface are entirely untested.
+- **The existing `tests/.../Integration/` directory is not integration tests.**
+  All three files wire real classes to `FakeProcessRunner` in-process. They are
+  good component tests under a misleading name.
+- **CI is `ubuntu-latest` only** across all six workflows. #118 was a
+  Linux/macOS bug found in production; there is no macOS signal at all.
+- **Parser tests feed hand-written gcdump text.** If JetBrains changes the real
+  report format, every test stays green and the product silently stops finding
+  anything.
+
+Two further untested seams found while designing:
+
+- `Program.cs` uses `WithToolsFromAssembly()` — reflection-based tool discovery.
+  A renamed class or changed attribute drops a tool from the manifest with no
+  compile error.
+- `MemoryLens.Mcp.csproj` stamps `.mcp/server.json` at pack time via an inline
+  Roslyn task doing a regex replace. If the regex stops matching, a package
+  ships with a wrong version and nothing complains.
+
+`samples/DotMemoryPathTest/` is a hand-run integration test — a console app
+exercising the real `ProcessRunner` and `DotMemoryToolManager`, exiting 0/1. It
+is not in the solution and CI never builds it. The project already wanted this
+tier; it has been running it manually.
+
+## Goals
+
+1. Make it impossible for the test rig to stop running without someone finding
+   out the same day.
+2. Cover the seams where real processes, real files, real permissions, and the
+   real MCP protocol are involved — the places both escapes lived.
+3. Keep the PR gate fast, hermetic, and trustworthy. A nightly flake must never
+   be able to block a merge.
+
+## Non-goals
+
+- Rewriting or reorganising the existing 137 unit tests. They are fine at what
+  they do; they are simply not the tier that catches these bugs.
+- Raising coverage as a number. This design targets specific, demonstrated
+  failure modes.
+- Testing JetBrains' profiler itself. We test that our integration with it
+  works.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Tier structure | Two separate test projects | The tiers have different dependencies (network, Docker, live processes), runtimes (seconds vs minutes), and failure semantics. Physical separation makes the PR gate's hermeticity structural, not a filter someone must remember. |
+| OS coverage | ubuntu + macos + windows | #118 was Unix-only and shipped. Windows currently has no coverage of any kind. |
+| E2E cadence | Nightly + manual dispatch | Real profiler downloads are slow and network-dependent. Never gates a PR. |
+| Shared helpers | A `TestSupport` classlib | `McpStdioClient` is a real component (process spawn, JSON-RPC framing, id correlation, timeouts, disposal), not a snippet to link into two projects. |
+| SDK roll-forward | `latestPatch` | Locks the feature band where behaviour changes land; still takes bugfix patches. |
+
+## Section 1 — The two tiers
+
+### `tests/MemoryLens.Mcp.IntegrationTests`
+
+Hermetic. Runs on every PR, on all three OSes. No network, no Docker, no
+dotMemory. All fixtures constructed by the test itself.
+
+| Test | Proves | Escape closed |
+|---|---|---|
+| Execute-bit restoration — build a zip containing a `#!` shebang script, an ELF-magic file, a Mach-O-magic file, an `MZ` managed assembly and a plain `.txt`; run real extraction + `MakeToolsExecutable`; assert modes | The byte-sniffing classifier sets exec bits on exactly the right files | #118 directly |
+| Real exec chain — two-hop fixture where script A execs script B, run through the real `ProcessRunner` after extraction | The second hop actually runs | #118's real failure mode |
+| Cache-hit path — run `MakeToolsExecutable` twice | The `UserExecute` early-skip does not wrongly skip a file | Regression in that optimisation |
+| stdio JSON-RPC handshake — spawn the built server, `initialize`, `tools/list` | Server starts, DI resolves, reflection-discovered tool set is exactly the expected six names | Broken wiring, silently dropped tool |
+| `get_rules` over the wire — real `tools/call` | A tool round-trips real JSON-RPC, not just a C# method call | Serialization/schema breakage |
+| Config loading — real `.memorylens.json` in a temp cwd | `ConfigLoader` reads from the working directory as `Program.cs` assumes | Silent config no-op |
+
+On Windows the exec-bit tests self-skip, since `MakeToolsExecutable` early-returns
+via `OperatingSystem.IsWindows()`. The stdio and config tests still run there,
+which is coverage that does not exist today.
+
+### `tests/MemoryLens.Mcp.EndToEndTests`
+
+Nightly and manually dispatchable. Never gates a PR.
+
+| Test | Proves |
+|---|---|
+| Real install — real nuget.org download, real extraction, real exec | The actual JetBrains package layout still works. This is `samples/DotMemoryPathTest` promoted to an automated test |
+| Live leak → snapshot → analyze | Launch the leaky fixture, take a real snapshot, run `analyze`, assert **specific rule IDs** fire. The core product promise, against real dotMemory output |
+| `compare_snapshots` on two real snapshots of a growing heap | Growth is detected on real data, not hand-written fixture text |
+| Docker — `docker build`, run the image, assert `tools/list` answers | The shipped image starts |
+| npm shim — execute `npm/bin/memorylens-mcp.js`, assert `tools/list` answers | The shipped wrapper starts |
+| Pack assertion — `dotnet pack`, unzip, assert `.mcp/server.json` version matches | The regex version stamp actually fired |
+
+## Section 2 — CI workflow layout
+
+### Constraint: the required check is named `build`
+
+Branch protection requires the status check `build`, which is today's job id in
+`ci.yml`. Converting `build` into a 3-OS matrix would rename the checks to
+`build (ubuntu-latest)` and friends, and the required context `build` would never
+report — stranding every PR on a pending check forever.
+
+The matrix therefore goes in a new job, and `build` survives as a single
+aggregating gate.
+
+```
+ci.yml  (pull_request + push to main)
+├── test   [matrix: ubuntu-latest, macos-latest, windows-latest]
+│   └── restore → build → unit tests + IntegrationTests
+├── build  [needs: test]              ← unchanged name, still the required check
+│   └── gitversion → build → pack → nuget push (main only)
+└── alert  [needs: [test, build], see condition below]
+    └── open-or-update "CI is red on main" issue
+```
+
+No branch-protection change is required, and `build` remains a stable gate even
+if OS legs are added later.
+
+**The alert condition must not be a bare `if: failure()`.** When `test` fails,
+`build` is skipped rather than failed, and a naive dependent job can be skipped
+along with it — producing an alert job that silently never fires in exactly the
+case it exists for. It must depend on both jobs and inspect their results
+explicitly:
+
+```yaml
+alert:
+  needs: [test, build]
+  if: >-
+    always() && github.event_name == 'push' &&
+    (needs.test.result == 'failure' || needs.build.result == 'failure')
+```
+
+The same applies to `e2e.yml`'s alert job: `always()` plus explicit
+`needs.<job>.result == 'failure'` checks, never a bare `failure()`.
+
+```
+e2e.yml  (schedule: nightly + workflow_dispatch)
+├── profiler  [matrix: ubuntu, macos, windows]   real dotMemory → snapshot → analyze → compare
+├── docker    [ubuntu]                           docker build → run → tools/list
+├── npm       [ubuntu]                           node bin shim → tools/list
+├── pack      [ubuntu]                           dotnet pack → unzip → assert server.json version
+└── alert     [needs: all, always() + result checks]   open-or-update "Nightly E2E failed" issue
+```
+
+### Cost
+
+PR CI moves from roughly 30s to roughly 2–4 minutes (3× matrix plus the
+integration tier). Mitigated with NuGet caching and a `concurrency` group that
+cancels superseded PR runs — which matters more once every push costs 3×.
+Nightly runs 10–20 minutes, dominated by the profiler download.
+
+## Section 3 — Rig guards
+
+These are independent of the tiers and close the hole that cost six days.
+
+### Minimum expected test count
+
+```xml
+<TestingPlatformCommandLineArguments>--minimum-expected-tests 130</TestingPlatformCommandLineArguments>
+```
+
+Per test application, not per solution. `130` against today's 137 is a floor, so
+adding tests never requires a bump, but a collapse in discovery fails loudly.
+This guards the dangerous variant of Escape 1: not the loud error that actually
+occurred, but a run discovering **zero** tests and reporting success. Each new
+test project gets its own floor as it fills.
+
+### SDK pin
+
+```json
+{
+  "sdk": { "version": "10.0.400", "rollForward": "latestPatch" },
+  "test": { "runner": "Microsoft.Testing.Platform" }
+}
+```
+
+Paired with switching `setup-dotnet` from `dotnet-version: 10.0.x` to
+`global-json-file: ./global.json`, so the runner installs exactly what the repo
+pins. Renovate can bump the pin as a reviewable PR.
+
+**Caveat, recorded deliberately:** this would *not* have caught Escape 1. That
+break came from the xunit v4 bump meeting an SDK major already in use. What the
+pin closes is the adjacent hole — a runner-side SDK bump changing build behaviour
+with no repo change at all, which is harder to diagnose because `git log` shows
+nothing.
+
+### Red-main alert
+
+An `alert` job gated on `if: failure() && github.event_name == 'push'`, with
+`issues: write`. It searches for an open issue labelled `ci-red`, comments if one
+exists, opens one if not — so six consecutive red commits produce one issue with
+six comments rather than six issues. A companion step on green closes any open
+`ci-red` issue with a "recovered on `<sha>`" comment.
+
+**This is the guard that would have saved the six days.**
+
+### `enforce_admins`
+
+```
+gh api -X POST repos/MarcelRoozekrans/memorylens-mcp/branches/main/protection/enforce_admins
+```
+
+Branch protection already requires the `build` check, but `enforce_admins` is off,
+which is how six red commits reached `main`. Verified that no workflow pushes
+directly to `main` — release-please operates through PRs and tags — so automation
+is unaffected.
+
+Consequence: the repo owner loses the ability to merge a red PR or push straight
+to `main`. That is the point, but it is a real change to how the owner works on
+their own repo. Reversible with `-X DELETE`.
+
+This is a GitHub settings change, applied as an explicit separate step rather
+than bundled into a code PR.
+
+## Section 4 — Fixture and shared test support
+
+### `tests/MemoryLens.Mcp.LeakyApp`
+
+A console app that leaks on purpose, in shapes the rules detect: a static event
+with accumulating subscribers (ML001), a growing static collection (ML002),
+undisposed streams (ML003), retained closure display-classes (ML007), duplicated
+strings (ML010).
+
+`compare_snapshots` needs two snapshots of the *same* process with real growth
+between them, so the app needs a control channel. Stdin commands, chosen over
+ports or sentinel files because there is no binding, no polling, and no timing
+race:
+
+```
+stdout: READY <pid>
+stdin:  grow  → allocate and retain another tranche → stdout: GROWN
+stdin:  exit  → clean shutdown
+```
+
+The E2E test waits for `READY`, snapshots, sends `grow`, waits for `GROWN`, and
+snapshots again.
+
+This lets the `analyze` test assert **specific rule IDs fired** rather than
+`count > 0` — and it is the only thing in this design that can catch a JetBrains
+report-format change, since every current parser test feeds hand-written text.
+
+Lives under `tests/` rather than `samples/` so CI compiles it and a broken fixture
+surfaces as a build error. Excluded from packing.
+
+### `tests/MemoryLens.Mcp.TestSupport`
+
+A classlib referenced by both tiers, holding:
+
+- **`McpStdioClient`** — spawns a child process, frames JSON-RPC over stdio,
+  correlates request/response ids, enforces timeouts, kills the process on
+  dispose. The integration tier points it at the built DLL; the E2E tier points
+  the same client at the Docker image and the npm shim. One client, three
+  transports' worth of coverage.
+- **`TempDir`** — disposable temp directory.
+- **`PackageFixtureBuilder`** — constructs a zip with shebang / ELF / Mach-O /
+  `MZ` / plain-text entries for the exec-bit tests.
+
+### Flakiness discipline
+
+The fastest way to waste this investment is a nightly that cries wolf.
+
+- Every spawned process gets a hard timeout and is killed on dispose.
+- Every test gets its own temp directory; never a shared path.
+- Nothing depends on wall-clock ordering or `Thread.Sleep`.
+- Profiler tests get generous attach timeouts; dotMemory is genuinely slow to
+  attach.
+
+### Wiring
+
+All four new projects go into `memorylens-mcp.slnx`. `InternalsVisibleTo` gains
+`MemoryLens.Mcp.IntegrationTests` and `MemoryLens.Mcp.EndToEndTests` — the
+exec-bit tests need `MakeToolsExecutable`, which is `internal static`.
+`TestSupport` and `LeakyApp` do not need it.
+
+## Sequencing
+
+Three phases, each independently shippable. The guards come first because they
+are small, independent, and close the hole that actually cost six days — there is
+no reason to hold them behind the larger build.
+
+**Phase 1 — Rig guards.** Min-test-count, SDK pin plus `global-json-file`,
+red-main alert, `enforce_admins`. Small, no new projects.
+
+**Phase 2 — Integration tier.** `TestSupport`, `IntegrationTests`, the `test`
+matrix job and the `build` aggregating gate. This is where #118's regression
+guard lands.
+
+**Phase 3 — E2E tier.** `LeakyApp`, `EndToEndTests`, `e2e.yml`. Gated on the
+licence question below.
+
+## Risks and open questions
+
+**dotMemory licence for CI use — resolve before Phase 3.** The nightly tier
+downloads and runs `JetBrains.dotMemory.Console` on GitHub-hosted runners. Whether
+JetBrains' licence permits automated CI use has not been verified, and this design
+does not assume it does.
+
+Resolution required before the `profiler` job is enabled. If CI use turns out to
+be restricted, the fallback is defined: the `profiler` leg becomes self-hosted or
+manual-dispatch-only, and the `docker`, `npm`, and `pack` legs stay nightly.
+Phases 1 and 2 are unaffected either way.
+
+**PR latency.** 3× matrix plus a new tier is a real cost on a repo whose CI
+currently finishes in 30 seconds. Caching and run-cancellation are part of Phase 2
+rather than a later optimisation.
+
+**Nightly trust.** If the nightly goes flaky it will be ignored, and an ignored
+alarm is worse than none. The flakiness discipline above is a requirement, not a
+guideline. If a nightly test cannot be made deterministic, it should be deleted
+rather than tolerated.
+
+## Appendix — Verified repro
+
+In a clean worktree at `ae0e957`, SDK 10.0.400:
+
+| State | Result |
+|---|---|
+| `main` as merged | `Passed! total: 137, failed: 0` |
+| `rm global.json` | `MTP targets(320,5): error : Testing with VSTest target is no longer supported` — build fails, 0 tests run |
+| `git checkout global.json` | `Passed! total: 137` |
+
+The failure is a pure function of that one file.

--- a/docs/superpowers/specs/2026-08-21-testing-rig-hardening-design.md
+++ b/docs/superpowers/specs/2026-08-21-testing-rig-hardening-design.md
@@ -334,6 +334,41 @@ guard lands.
 **Phase 3 — E2E tier.** `LeakyApp`, `EndToEndTests`, `e2e.yml`. Gated on the
 licence question below.
 
+### Phase 2 prerequisites discovered during Phase 1
+
+Phase 1 shipped as `a89a234..f0776d9`. Executing it surfaced four traps that
+Phase 2 must handle. They are recorded here rather than in an execution ledger
+because that ledger is scratch and will not survive.
+
+1. **The alert's `needs` list is load-bearing.** Phase 1's alert job is
+   `needs: [build]` and its open-issue step fires on `needs.build.result != 'success'`
+   — deliberately `!= 'success'` rather than `== 'failure'`, because a fail-fast
+   matrix *cancels* sibling legs and `cancelled` would otherwise alert nobody.
+   When Phase 2 introduces the `test` matrix job, it must add `test` to `needs`
+   **and** to the result checks. Adding it to `needs` alone reintroduces the gap.
+
+2. **The min-test floor must move with the tests.** The floor of `130` is
+   calibrated against 137 in `MemoryLens.Mcp.Tests`. If the 22 tests under
+   `tests/MemoryLens.Mcp.Tests/Integration/` are relocated into the real
+   integration tier — a natural move, since this spec calls that directory
+   misleadingly named — the count drops to roughly 115 and the floor fails
+   as what looks like a false alarm. Lower the floor in the same commit that
+   moves the tests.
+
+3. **Windows self-skips must not break the new project's floor.** Section 1
+   says the exec-bit tests self-skip on Windows. If they use xunit's `Skip =`,
+   they may not count toward `--minimum-expected-tests`, so a floor calibrated
+   on Linux fails the Windows leg. The existing suite avoids this by branching
+   *inside* the test body (see `DiagnosticPortProcessListerTests.cs` and
+   `DotMemoryAutoInstallerTests.cs`), which keeps them counted as passed.
+   Follow that pattern, or make the new project's floor OS-conditional.
+
+4. **The Docker build is outside the SDK pin, deliberately.** `Dockerfile` builds
+   on the floating `mcr.microsoft.com/dotnet/sdk:10.0` tag and does **not** copy
+   `global.json`. Copying it would hard-break the image as soon as that tag rolls
+   to a `10.0.5xx` band, since the pin is `latestPatch`. A comment in the
+   Dockerfile records this. Phase 3's Docker E2E test must not "fix" it.
+
 ## Risks and open questions
 
 **dotMemory licence for CI use — resolve before Phase 3.** The nightly tier


### PR DESCRIPTION
The design spec and implementation plan behind #153.

## Contents

- `docs/superpowers/specs/2026-08-21-testing-rig-hardening-design.md` — the design
- `docs/superpowers/plans/2026-08-21-rig-guards-phase-1.md` — the Phase 1 plan #153 executes

## The argument

Two failures escaped the testing rig within a month, and they are **different in kind**:

1. **The rig stopped running.** The MTP break (#150) — CI red for six days, loud from run one, nobody listening.
2. **The rig ran fine and tested nothing real.** #118 — `ZipFile.ExtractToDirectory` discards Unix permission bits, so `snapshot`, `compare_snapshots` and `analyze` were unusable on Linux and macOS. **All 137 tests were green throughout**, and necessarily so.

Fixing one does nothing for the other.

## Why the current suite could not have caught either

Verified against the tree, not assumed:

- **No test spawns a real process** — zero hits for `Process.Start` / `new ProcessRunner()` under `tests/`. Everything routes through `FakeProcessRunner`, so a missing execute bit is structurally invisible.
- **No test touches `Program.cs`, the DI container, or the MCP protocol** — zero hits for `CreateApplicationBuilder` / `IHost` / `ServiceProvider`.
- **The existing `tests/.../Integration/` directory is not integration tests** — all three files wire real classes to fakes in-process. Good component tests under a misleading name.
- **CI is `ubuntu-latest` only** across all six workflows, and #118 was a Unix bug.
- **Parser tests feed hand-written gcdump text**, so a JetBrains format change would leave every test green while the product silently stops finding anything.

Two further untested seams: `Program.cs` uses reflection-based tool discovery (`WithToolsFromAssembly()`), and pack-time version stamping is a regex replace that fails silently.

`samples/DotMemoryPathTest/` turns out to be a hand-run integration test that CI never builds — the project already wanted this tier.

## The plan

Three independently shippable phases: **guards first** (#153), then a hermetic integration tier on every PR across three OSes, then a nightly E2E tier driving real dotMemory, Docker and the npm shim.

Phase 3 is explicitly **gated on verifying JetBrains' licence permits dotMemory in CI**, with a defined fallback if it does not. That question is recorded as a gate, not assumed away.

## Recorded honestly

The spec states plainly that **the SDK pin would not have caught the break it was written in response to**. It closes an adjacent hole (runner-side SDK drift with no repo change). Recorded so nobody later reads it as the fix for this incident.

The final section — Phase 2 prerequisites — was added *after* executing Phase 1, capturing four traps that only surfaced during execution. Most important: a fail-fast matrix **cancels** sibling legs, so Phase 2 must add the matrix job to both the alert's `needs` list *and* its result checks. Adding it to `needs` alone silently reintroduces the gap this work just closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
