### PR TITLE
fix: treat an empty snapshotPath as absent, not as a path

### DIFF
--- a/src/MemoryLens.Mcp/Analysis/AnalysisEngine.cs
+++ b/src/MemoryLens.Mcp/Analysis/AnalysisEngine.cs
@@ -85,7 +85,13 @@ public class AnalysisEngine
         // production code, Data stayed null, every rule took its `Data is null`
         // early-out, and the happy path answered "no memory issues found" on a leaking
         // heap -- the exact silent-wrong-answer shape this pipeline exists to eliminate.
-        var locator = context.SnapshotPath ?? context.SnapshotId;
+        // Empty is treated as absent, not as a path. A calling model routinely emits ""
+        // for an optional string, and a null-only fallback would let that skip the read
+        // entirely -- reinstating the silent "no memory issues found" this code exists
+        // to prevent, for an input that previously threw.
+        var locator = string.IsNullOrEmpty(context.SnapshotPath)
+            ? context.SnapshotId
+            : context.SnapshotPath;
 
         if (!string.IsNullOrEmpty(locator))
         {

--- a/tests/MemoryLens.Mcp.Tests/Integration/AnalyzeToolIntegrationTests.cs
+++ b/tests/MemoryLens.Mcp.Tests/Integration/AnalyzeToolIntegrationTests.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using MemoryLens.Mcp.Analysis;
 using MemoryLens.Mcp.Config;
 using MemoryLens.Mcp.Profiler;
@@ -183,6 +183,37 @@ public class AnalyzeToolIntegrationTests
                 $"that is full of leaks. A bare snapshot id must resolve. Raw: {json}");
             Assert.True(findings.GetArrayLength() > 0);
             Assert.Equal(count, findings.GetArrayLength());
+        }
+        finally { if (Directory.Exists(root)) Directory.Delete(root, true); }
+    }
+
+    /// <summary>
+    /// An empty snapshotPath must behave like no snapshotPath, not like a valid one.
+    /// A calling model routinely emits "" for an optional string parameter, and a
+    /// null-only fallback lets that slip past the locator check: Data stays null,
+    /// every rule takes its early-out, and analyze answers "no memory issues found"
+    /// on a leaking heap. Before the bare-id fix this input threw; it must not have
+    /// become quieter.
+    /// </summary>
+    [Fact]
+    public async Task Analyze_WithEmptySnapshotPath_StillResolvesTheBareId()
+    {
+        var root = NewRoot();
+        try
+        {
+            var (store, id) = await SaveAsync(root, LeakyAppSnapshot(), TestContext.Current.CancellationToken);
+            var engine = new AnalysisEngine(new MemoryLensConfig(), new SnapshotReader(store));
+            var tool = new AnalyzeTool(engine);
+
+            var json = await tool.analyze(id, snapshotPath: "", ct: TestContext.Current.CancellationToken);
+
+            var doc = JsonDocument.Parse(json);
+            var count = doc.RootElement.GetProperty("count").GetInt32();
+
+            Assert.True(count > 0,
+                $"analyze('{id}', snapshotPath: \"\") reported {count} findings on a snapshot " +
+                $"full of leaks. An empty path must fall back to the id, not silently " +
+                $"skip the read. Raw: {json}");
         }
         finally { if (Directory.Exists(root)) Directory.Delete(root, true); }
     }

--- a/tests/MemoryLens.Mcp.Tests/MemoryLens.Mcp.Tests.csproj
+++ b/tests/MemoryLens.Mcp.Tests/MemoryLens.Mcp.Tests.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <!-- Recalibrated from the real count: 103 tests, floor = actual - 2. -->
-    <TestingPlatformCommandLineArguments>--minimum-expected-tests 101</TestingPlatformCommandLineArguments>
+    <TestingPlatformCommandLineArguments>--minimum-expected-tests 102</TestingPlatformCommandLineArguments>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes the one defect I parked before #163 merged.

## The bug

#163 fixed `analyze` ignoring a bare snapshot id, using:

```csharp
var locator = context.SnapshotPath ?? context.SnapshotId;
```

That falls back only on **null**. An empty string is not null — so with `snapshotPath: ""`, the locator becomes `""`, the read is skipped, `Data` stays null, every rule takes its `context.Data is null` early-out, and the tool answers:

```json
{"findings": [], "count": 0}
```

on a heap full of leaks.

**That input previously threw** a `FileNotFoundException`. So the fix made one input *quieter* rather than louder — reinstating, for that case, the exact silent-wrong-answer shape this whole pipeline exists to eliminate.

It matters because `""` is a routine emission from a calling model for an optional string parameter. This is not an exotic input; it is one of the two things an agent will actually send.

## The fix

```csharp
var locator = string.IsNullOrEmpty(context.SnapshotPath)
    ? context.SnapshotId
    : context.SnapshotPath;
```

Empty is treated as absent, not as a path.

## The test

`Analyze_WithEmptySnapshotPath_StillResolvesTheBareId` calls the tool the way a model would — `analyze(id, snapshotPath: "")` — and asserts findings are non-empty. Verified red against the previous code:

```
analyze('70581b07', snapshotPath: "") reported 0 findings on a snapshot full of leaks.
An empty path must fall back to the id, not silently skip the read.
```

Note where it lives: alongside `Analyze_WithBareSnapshotIdAndNoPath_ReturnsFindings`, because the same blind spot produced both. Every earlier test either passed `snapshotPath` explicitly or built the context by hand, so neither of the two ways a caller actually invokes `analyze` had coverage.

## Also

Unit floor raised 101 → 102 to keep the actual-minus-2 convention (104 tests now), and verified to fire in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
