### PR TITLE
fix(ci): shorten server.json description to the registry's 100-char cap

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -37,9 +37,21 @@ jobs:
           for attempt in $(seq 1 "$max_attempts"); do
             if ! ./mcp-publisher login github-oidc; then
               echo "::warning::OIDC login failed on attempt $attempt/$max_attempts."
-            elif ./mcp-publisher publish; then
-              echo "Published to MCP Registry on attempt $attempt."
-              exit 0
+            else
+              if ./mcp-publisher publish >publish.log 2>&1; then
+                cat publish.log
+                echo "Published to MCP Registry on attempt $attempt."
+                exit 0
+              fi
+              cat publish.log
+              # A 422 means the registry read the payload and rejected its CONTENTS
+              # (e.g. a description over the schema's 100-char cap). Time cannot fix
+              # that, so stop here. Without this check the loop reported a hard
+              # validation error as indexing lag and burned 25 min doing it.
+              if grep -q 'status 422' publish.log; then
+                echo "::error::MCP Registry rejected server.json as invalid (HTTP 422) -- see the validation errors above. This is a payload problem, not NuGet indexing lag; retrying cannot help."
+                exit 1
+              fi
             fi
             if [ "$attempt" -lt "$max_attempts" ]; then
               echo "::notice::MCP Registry publish attempt $attempt/$max_attempts failed (NuGet may still be indexing); retrying in ${delay}s"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -114,9 +114,21 @@ jobs:
           for attempt in $(seq 1 "$max_attempts"); do
             if ! ./mcp-publisher login github-oidc; then
               echo "::warning::OIDC login failed on attempt $attempt/$max_attempts."
-            elif ./mcp-publisher publish; then
-              echo "Published $VERSION to MCP Registry on attempt $attempt."
-              exit 0
+            else
+              if ./mcp-publisher publish >publish.log 2>&1; then
+                cat publish.log
+                echo "Published $VERSION to MCP Registry on attempt $attempt."
+                exit 0
+              fi
+              cat publish.log
+              # A 422 means the registry read the payload and rejected its CONTENTS
+              # (e.g. a description over the schema's 100-char cap). Time cannot fix
+              # that, so stop here. Without this check the loop reported a hard
+              # validation error as indexing lag and burned 25 min doing it.
+              if grep -q 'status 422' publish.log; then
+                echo "::error::MCP Registry rejected server.json as invalid (HTTP 422) -- see the validation errors above. This is a payload problem, not NuGet indexing lag; retrying cannot help."
+                exit 1
+              fi
             fi
             if [ "$attempt" -lt "$max_attempts" ]; then
               echo "::notice::MCP Registry publish attempt $attempt/$max_attempts failed (NuGet is likely still indexing $VERSION); retrying in ${delay}s"

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.MarcelRoozekrans/memorylens-mcp",
-  "description": "MCP server for .NET memory profiling — collects heap snapshots in-process via EventPipe and applies a heuristic rule engine",
+  "description": "MCP server for .NET memory profiling — in-process heap snapshots via EventPipe with leak heuristics",
   "repository": {
     "url": "https://github.com/MarcelRoozekrans/memorylens-mcp",
     "source": "github"

--- a/src/MemoryLens.Mcp/.mcp/server.json
+++ b/src/MemoryLens.Mcp/.mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.marcelroozekrans/memorylens-mcp",
-  "description": "MCP server for .NET memory profiling — collects heap snapshots in-process via EventPipe and applies a heuristic rule engine",
+  "description": "MCP server for .NET memory profiling — in-process heap snapshots via EventPipe with leak heuristics",
   "title": "MemoryLens",
   "repository": {
     "url": "https://github.com/MarcelRoozekrans/memorylens-mcp",

--- a/src/MemoryLens.Mcp/MemoryLens.Mcp.csproj
+++ b/src/MemoryLens.Mcp/MemoryLens.Mcp.csproj
@@ -12,7 +12,7 @@
     <ToolCommandName>memorylens-mcp</ToolCommandName>
     <PackageId>MemoryLens.Mcp</PackageId>
     <Authors>Marcel Roozekrans</Authors>
-    <Description>MCP server for .NET memory profiling — collects heap snapshots in-process via EventPipe and applies a heuristic rule engine</Description>
+    <Description>MCP server for .NET memory profiling — in-process heap snapshots via EventPipe with leak heuristics</Description>
     <PackageProjectUrl>https://github.com/MarcelRoozekrans/memorylens-mcp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/MarcelRoozekrans/memorylens-mcp</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## What broke

The MCP Registry publish job failed the 2.1.1 release. The job's own logs blamed NuGet indexing lag, but every one of the 15 attempts failed instantly and identically with a hard validation rejection:

```
status 422: {"detail":"validation failed","errors":[
  {"message":"expected length <= 100","location":"body.description", ...}]}
```

The `description` was **123 characters**. The published schema (`.../2025-12-11/server.schema.json`) caps `description` at `maxLength: 100`, so 2.1.1 could never have published no matter how long it waited.

## Two bugs

**1. The payload was invalid.** Shortened the description to 99 chars, kept identical across the three places it is duplicated — root `server.json`, the packed `.mcp/server.json`, and the csproj `<Description>`:

> MCP server for .NET memory profiling — in-process heap snapshots via EventPipe with leak heuristics

The csproj has no length limit; it's synced only so the three don't drift apart.

**2. The retry loop couldn't tell "wait" from "wrong"** — the worse bug. It treated every failure as indexing lag, so it retried a permanent validation error 15 times over 25 minutes and buried the real cause behind a `NuGet is likely still indexing` notice. That notice is what sent the investigation chasing indexing lag instead of the payload.

The loop now captures publisher output, always prints it, and exits immediately on a 422 with an error saying it's a payload problem. Non-422 failures still retry with the same backoff, since indexing lag is a real failure mode. Applied to both `release-please.yml` and `publish-mcp-registry.yml`.

## Verification

- Both `server.json` files validate clean against the live registry schema (ajv, draft-7).
- `dotnet pack` succeeds; unzipped the nupkg and confirmed the packed `.mcp/server.json` carries the 99-char description and the correctly stamped version.
- Extracted the new loop from the workflow and ran it against a stub publisher:
  - 422 → **exit 1 in 0s** (was 25 min)
  - success → exit 0 on attempt 1
  - transient 404 → retries, succeeds on attempt 3 after 91s of backoff

## After merging

The registry entry for 2.1.1 is still stale. NuGet has long since indexed 2.1.1, so re-run **Actions → Publish to MCP Registry → Run workflow**; it should go through on the first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
